### PR TITLE
general cleanup, PEP8, function headers, arg/return types

### DIFF
--- a/bitmind/image_dataset.py
+++ b/bitmind/image_dataset.py
@@ -96,8 +96,8 @@ class ImageDataset:
         else:
             raise NotImplementedError
 
-        # check for/remove alpha channel if download didnt 404
-        if image is not None and 'A' in image.mode:
+        # emove alpha channel if download didnt 404
+        if image is not None:
             image = image.convert('RGB')
 
         return {

--- a/bitmind/image_dataset.py
+++ b/bitmind/image_dataset.py
@@ -1,50 +1,9 @@
-from typing import List
-from collections import defaultdict
-from datasets import load_dataset
+from typing import List, Tuple
 from PIL import Image
 from io import BytesIO
-import bittensor as bt
 import numpy as np
-import requests
-import base64
 
-
-def download_image(url):
-    #print(f'downloading {url}')
-    response = requests.get(url)
-    if response.status_code == 200:
-        image_data = BytesIO(response.content)
-        return Image.open(image_data)
-
-    else:
-        #print(f"Failed to download image: {response.status_code}")
-        return None
-
-
-def load_huggingface_dataset(path, split=None, name=None, create_splits=False, download_mode=None):
-    if 'imagefolder' in path:
-        _, directory = path.split(':')
-        dataset = load_dataset(path='imagefolder', data_dir=directory, split='train')
-    else:
-        dataset = load_dataset(path, name=name, download_mode=download_mode)#, split=split)
-
-    if not create_splits:
-        if split is not None:
-            return dataset[split]
-        return dataset
-
-    dataset = dataset.shuffle(seed=42)
-
-    split_dataset = {}
-    train_test_split = dataset['train'].train_test_split(test_size=0.2, seed=42)
-    split_dataset['train'] = train_test_split['train']
-    temp_dataset = train_test_split['test']
-
-    # Split the temporary dataset into validation and test
-    val_test_split = temp_dataset.train_test_split(test_size=0.5, seed=42)
-    split_dataset['validation'] = val_test_split['train']
-    split_dataset['test'] = val_test_split['test']
-    return split_dataset[split]
+from bitmind.utils.data import load_huggingface_dataset, download_image
 
 
 class ImageDataset:
@@ -57,29 +16,62 @@ class ImageDataset:
         create_splits: bool = False,
         download_mode: str = None
     ):
+        """
+        Args:
+            huggingface_dataset_path (str): Path to the Hugging Face dataset. Can either be to a publicly hosted
+                huggingface datset (<organizatoin>/<datset-name>) or a local directory (imagefolder:<path/to/directory>)
+            huggingface_dataset_split (str): Split of the dataset to load (default: 'train').
+                Make sure to check what splits are available for the datasets you're working with.
+            huggingface_dataset_name (str): Name of the Hugging Face dataset (default: None).
+                Some huggingface datasets provide various subets of different sizes, which can be accessed via thi
+                parameter.
+            create_splits (bool): Whether to create dataset splits (default: False).
+                If the huggingface dataset hasn't been pre-split (i.e., it only contains "Train"), we split it here
+                randomly.
+            download_mode (str): Download mode for the dataset (default: None).
+                can be None or "force_redownload"
+        """
         self.huggingface_dataset_path = huggingface_dataset_path
         self.huggingface_datset_name = huggingface_datset_name
         self.dataset = load_huggingface_dataset(
             huggingface_dataset_path, huggingface_datset_split, huggingface_datset_name, create_splits, download_mode)
         self.sampled_images_idx = []
 
-    def __getitem__(self, index):
-        return self._get_image(index)
-
-    def __len__(self):
-        return len(self.dataset)
-
-    def _get_image(self, index: int):
+    def __getitem__(self, index: int) -> dict:
         """
-        Loads an image from self.dataset. Expects self.dataset[i] to be a dictionary containing
-        either 'image' or 'url' as a key.
-            - The value associated with the 'image' key should be either a PIL image or a
-                b64 string encoding of the image.
-            - The value associated with the 'url' key should be a url that hosts the image
-                (as in dalle-mini/open-images)
+        Get an item (image and ID) from the dataset.
+
+        Args:
+            index (int): Index of the item to retrieve.
 
         Returns:
-            {'image': PIL.image, 'id': str}
+            dict: Dictionary containing 'image' (PIL image) and 'id' (str).
+        """
+        return self._get_image(index)
+
+    def __len__(self) -> int:
+        """
+        Get the length of the dataset.
+
+        Returns:
+            int: Length of the dataset.
+        """
+        return len(self.dataset)
+
+    def _get_image(self, index: int) -> dict:
+        """
+        Load an image from self.dataset. Expects self.dataset[i] to be a dictionary containing either 'image' or 'url'
+        as a key.
+            - The value associated with the 'image' key should be either a PIL image or a b64 string encoding of
+            the image.
+            - The value associated with the 'url' key should be a url that hosts the image (as in
+            dalle-mini/open-images)
+
+        Args:
+            index (int): Index of the image in the dataset.
+
+        Returns:
+            dict: Dictionary containing 'image' (PIL image) and 'id' (str).
         """
         sample = self.dataset[int(index)]
         if 'url' in sample:
@@ -113,13 +105,16 @@ class ImageDataset:
             'id': image_id,
         }
 
-    def sample(self, k=1):
+    def sample(self, k: int = 1) -> Tuple[List[dict], List[int]]:
         """
-        Randomly samples k images from self.dataset. Includes retries for failed downloads,
-        in the case that self.dataset contains urls.
+        Randomly sample k images from self.dataset. Includes retries for failed downloads, in the case that
+        self.dataset contains urls.
+
+        Args:
+            k (int): Number of images to sample (default: 1).
 
         Returns:
-            a tuple containing a list of the sampled images and a list of ther indices
+            Tuple[List[dict], List[int]]: A tuple containing a list of sampled images and their indices.
         """
         sampled_images = []
         sampled_idx = []

--- a/bitmind/image_transforms.py
+++ b/bitmind/image_transforms.py
@@ -1,5 +1,4 @@
 import torchvision.transforms as transforms
-import torch
 
 
 def CenterCrop():
@@ -10,6 +9,7 @@ def CenterCrop():
     return fn
 
 
+# transforms to prepare an image for the base miner.
 base_transforms = transforms.Compose([
     CenterCrop(),
     transforms.Resize((224, 224)),
@@ -17,6 +17,7 @@ base_transforms = transforms.Compose([
     transforms.Lambda(lambda t: t.expand(3, -1, -1) if t.shape[0] == 1 else t),
 ])
 
+# example data augmentation
 random_image_transforms = transforms.Compose([
     transforms.RandomResizedCrop(256), 
     transforms.RandomHorizontalFlip(),

--- a/bitmind/miner/predict.py
+++ b/bitmind/miner/predict.py
@@ -1,7 +1,21 @@
+from PIL import Image
+import torch
+
 from bitmind.image_transforms import base_transforms
 
 
-def predict(model, image):
+def predict(model: torch.nn.Module, image: Image.Image) -> float:
+    """
+    Perform prediction using a given PyTorch model on an image. You may need to modify this
+    if you train a custom model.
+
+    Args:
+        model (torch.nn.Module): The PyTorch model to use for prediction.
+        image (Image.Image): The input image as a PIL Image.
+
+    Returns:
+        float: The predicted output value.
+    """
     image = base_transforms(image).unsqueeze(0).float()
     out = model(image).sigmoid().flatten().tolist()
     return out[0]

--- a/bitmind/protocol.py
+++ b/bitmind/protocol.py
@@ -27,11 +27,21 @@ import pydantic
 import base64
 
 
-def prepare_image_synapse(image):
+def prepare_image_synapse(image: Image):
+    """
+    Prepares an image for use with ImageSynapse object.
+
+    Args:
+        image (Image): The input image to be prepared.
+
+    Returns:
+        ImageSynapse: An instance of ImageSynapse containing the encoded image and a default prediction value.
+    """
     image_bytes = BytesIO()
     image.save(image_bytes, format="JPEG")
     b64_encoded_image = base64.b64encode(image_bytes.getvalue())
     return ImageSynapse(image=b64_encoded_image, prediction=-1.)
+
 
 # ---- miner ----
 # Example usage:

--- a/bitmind/random_image_generator.py
+++ b/bitmind/random_image_generator.py
@@ -58,10 +58,15 @@ class RandomImageGenerator:
             bt.logging.info("A random image generation model will be loaded on each generation step.")
             self.diffuser = None
 
-
-    def generate(self, k=1):
+    def generate(self, k: int = 1) -> list:
         """
+        Generates k prompts using self.prompt_generator, then passes those to self.diffuser to generate k images.
 
+        Args:
+            k (int): Number of images to generate.
+
+        Returns:
+            list: List of dictionaries containing 'prompt', 'image', and 'id'.
         """
         if self.use_random_diffuser:
             self.load_random_diffuser()
@@ -88,7 +93,10 @@ class RandomImageGenerator:
 
         return gen_data
 
-    def load_random_diffuser(self):
+    def load_random_diffuser(self) -> None:
+        """
+        Clears GPU memory, then loads a random diffuser model.
+        """
         if self.diffuser is not None:
             bt.logging.info(f"Deleting previous diffuser, freeing memory")
             self.diffuser.to('cpu')
@@ -103,7 +111,16 @@ class RandomImageGenerator:
             diffuser_name, torch_dtype=torch.float16, **DIFFUSER_ARGS[diffuser_name])
         self.diffuser.to("cuda")
 
-    def generate_prompt(self, retry_attempts=10):
+    def generate_prompt(self, retry_attempts: int = 10) -> str:
+        """
+        Generates a prompt for image generation.
+
+        Args:
+            retry_attempts (int): Number of attempts to generate a valid prompt.
+
+        Returns:
+            str: Generated prompt.
+        """
         seed = random.randint(100, 1000000)
         set_seed(seed)
 

--- a/bitmind/real_fake_dataset.py
+++ b/bitmind/real_fake_dataset.py
@@ -5,16 +5,22 @@ class RealFakeDataset:
 
     def __init__(
         self,
-        real_image_datasets,
-        fake_image_datasets,
-        image_generator=None,
+        real_image_datasets: list,
+        fake_image_datasets: list,
         transforms=None,
         fake_prob=0.5,
     ):
+        """
+        Initialize the RealFakeDataset instance.
 
+        Args:
+            real_image_datasets (list): List of ImageDataset objects containing real images
+            fake_image_datasets (list): List of ImageDataset objects containing real images
+            transforms (transforms.Compose): Image transformations (default: None).
+            fake_prob (float): Probability of selecting a fake image (default: 0.5).
+        """
         self.real_image_datasets = real_image_datasets
         self.fake_image_datasets = fake_image_datasets
-        self.image_generator = image_generator
         self.transforms = transforms
         self.fake_prob = fake_prob
 
@@ -24,8 +30,17 @@ class RealFakeDataset:
             'label': [],
         }
 
-    def __getitem__(self, index):
+    def __getitem__(self, index: int) -> tuple:
+        """
+        Retrieve an item (image, label) from the dataset.
+        By default, 50/50 chance of real or fake. This can be overidden by self.fake_prob
 
+        Args:
+            index (int): Index of the item to retrieve.
+
+        Returns:
+            tuple: Tuple containing the image and its label.
+        """
         if len(self._history['index']) > index:
             self.reset()
 
@@ -54,9 +69,14 @@ class RealFakeDataset:
 
         return image, label
 
+    def __len__(self) -> int:
+        """
+        Return the length of the dataset.
 
-    def __len__(self):
-        """ This limits the number of images sampled each epoch to the length of the smallest dataset """
+        Returns:
+            int: Length of the dataset (minimum length between fake and real datasets, which  limits the number of
+            images sampled each epoch to the length of the smallest dataset to avoid imbalance).
+        """
         real_dataset_min = min([len(ds) for ds in self.real_image_datasets])
         fake_dataset_min = min([len(ds) for ds in self.fake_image_datasets])
         return min(fake_dataset_min, real_dataset_min)

--- a/bitmind/utils/data.py
+++ b/bitmind/utils/data.py
@@ -1,0 +1,79 @@
+from typing import Optional, Union
+from datasets import load_dataset
+from PIL import Image
+from io import BytesIO
+import requests
+import datasets
+
+
+def download_image(url: str) -> Image.Image:
+    """
+    Download an image from a URL.
+
+    Args:
+        url (str): The URL of the image to download.
+
+    Returns:
+        Image.Image or None: The downloaded image as a PIL Image object if successful,
+                             otherwise None.
+    """
+    response = requests.get(url)
+    if response.status_code == 200:
+        image_data = BytesIO(response.content)
+        return Image.open(image_data)
+
+    else:
+        #print(f"Failed to download image: {response.status_code}")
+        return None
+
+
+def load_huggingface_dataset(
+    path: str,
+    split: Optional[str] = None,
+    name: Optional[str] = None,
+    create_splits: bool = False,
+    download_mode: Optional[str] = None
+) -> Union[dict, datasets.Dataset]:
+    """
+    Load a dataset from Hugging Face or a local directory.
+
+    Args:
+        path (str): Path to the dataset or 'imagefolder:<directory>' for image folder. Can either be to a publicly
+            hosted huggingface datset with the format <organizatoin>/<datset-name> or a local directory with the format
+            imagefolder:<path/to/directory>
+        split (str, optional): Name of the dataset split to load (default: None).
+            Make sure to check what splits are available for the datasets you're working with.
+        name (str, optional): Name of the dataset (if loading from Hugging Face, default: None).
+            Some huggingface datasets provide various subets of different sizes, which can be accessed via thi
+            parameter.
+        create_splits (bool, optional): Whether to create train/validation/test splits (default: False).
+            If the huggingface dataset hasn't been pre-split (i.e., it only contains "Train"), we split it here
+            randomly.
+        download_mode (str, optional): Download mode for the dataset (if loading from Hugging Face, default: None).
+            can be None or "force_redownload"
+    Returns:
+        Union[dict, load_dataset.Dataset]: The loaded dataset or a specific split of the dataset as requested.
+    """
+    if 'imagefolder' in path:
+        _, directory = path.split(':')
+        dataset = load_dataset(path='imagefolder', data_dir=directory, split='train')
+    else:
+        dataset = load_dataset(path, name=name, download_mode=download_mode)#, split=split)
+
+    if not create_splits:
+        if split is not None:
+            return dataset[split]
+        return dataset
+
+    dataset = dataset.shuffle(seed=42)
+
+    split_dataset = {}
+    train_test_split = dataset['train'].train_test_split(test_size=0.2, seed=42)
+    split_dataset['train'] = train_test_split['train']
+    temp_dataset = train_test_split['test']
+
+    # Split the temporary dataset into validation and test
+    val_test_split = temp_dataset.train_test_split(test_size=0.5, seed=42)
+    split_dataset['validation'] = val_test_split['train']
+    split_dataset['test'] = val_test_split['test']
+    return split_dataset[split]

--- a/bitmind/utils/miner_metrics.py
+++ b/bitmind/utils/miner_metrics.py
@@ -1,9 +1,21 @@
 from collections import defaultdict
 import pandas as pd
 import numpy as np
+from typing import Union
 
 
-def miner_metrics(results_df, transpose=True):
+def miner_metrics(results_df: pd.DataFrame, transpose: bool = True) -> pd.DataFrame:
+    """
+    Calculate and display miner statistics and performance metrics.
+
+    Args:
+        results_df (pd.DataFrame): DataFrame containing miner results with columns
+            ['time', 'miner_uid', 'label', 'pred', 'image_source'].
+        transpose (bool): Whether to transpose the final metrics DataFrame.
+
+    Returns:
+        pd.DataFrame: DataFrame containing miner performance metrics.
+    """
     print(f'Miner Statistics | {results_df.time.min()} - {results_df.time.max()}')
     
     miner_preds_df = results_df.groupby('miner_uid')[['label', 'pred']].agg(list)
@@ -33,7 +45,16 @@ def miner_metrics(results_df, transpose=True):
     return metrics_df
 
 
-def compute_metrics(miner_preds_df):
+def compute_metrics(miner_preds_df: pd.DataFrame) -> pd.DataFrame:
+    """
+    Compute performance metrics for miners.
+
+    Args:
+        miner_preds_df (pd.DataFrame): DataFrame grouped by 'miner_uid' with aggregated lists of 'label' and 'pred'.
+
+    Returns:
+        pd.DataFrame: DataFrame containing accuracy, precision, recall, f-1, and num_predictions
+    """
     perf_data = defaultdict(list)
     perf_data['miner_uid'] = miner_preds_df.index.unique()
     for uid in perf_data['miner_uid']:

--- a/bitmind/validator/forward.py
+++ b/bitmind/validator/forward.py
@@ -39,8 +39,18 @@ from bitmind.image_transforms import random_image_transforms
 async def forward(self):
     """
     The forward function is called by the validator every time step.
-
     It is responsible for querying the network and scoring the responses.
+
+    Steps are:
+    1. Sample miner UIDs
+    2. Get an image. 50/50 chance of:
+        A. REAL (label = 0): Randomly sample a real image from self.real_image_datasets
+        B. FAKE (label = 1): Generate a synthetic image with self.random_image_generator
+    3. Apply random data augmentation to the image
+    4. Base64 encode the image and prepare an ImageSynapse
+    5. Query miner axons
+    6. Log results, including image and miner responses (soon to be W&B)
+    7. Compute rewards and update scores
 
     Args:
         self (:obj:`bittensor.neuron.Neuron`): The neuron object which contains all the necessary state for the validator.

--- a/neurons/miner.py
+++ b/neurons/miner.py
@@ -46,7 +46,7 @@ class Miner(BaseMinerNeuron):
         self, synapse: ImageSynapse
     ) -> ImageSynapse:
         """
-        Loads the PyTorch binary deepfake classifier from the path specified in --neuron.model_path.
+        Loads the deepfake detection model (a PyTorch binary classifier) from the path specified in --neuron.model_path.
         Processes the incoming ImageSynapse and passed the image to the loaded model for classification.
         The model is loaded here, rather than in __init__, so that miners may (backup) and overwrite
         their model file as a means of updating their miner's predictor.

--- a/neurons/miner.py
+++ b/neurons/miner.py
@@ -38,13 +38,6 @@ from bitmind.miner.predict import predict
 
 
 class Miner(BaseMinerNeuron):
-    """
-    Your miner neuron class. You should use this class to define your miner's behavior. In particular, you should replace the forward function with your own logic. You may also want to override the blacklist and priority functions according to your needs.
-
-    This class inherits from the BaseMinerNeuron class, which in turn inherits from BaseNeuron. The BaseNeuron class takes care of routine tasks such as setting up wallet, subtensor, metagraph, logging directory, parsing config, etc. You can override any of the methods in BaseNeuron if you need to customize the behavior.
-
-    This class provides reasonable default behavior for a miner such as blacklisting unrecognized hotkeys, prioritizing requests based on stake, and forwarding requests to the forward function. If you need to define custom
-    """
 
     def __init__(self, config=None):
         super(Miner, self).__init__(config=config)
@@ -53,8 +46,10 @@ class Miner(BaseMinerNeuron):
         self, synapse: ImageSynapse
     ) -> ImageSynapse:
         """
-        Processes the incoming ImageSynapse, running each image in the 'images' field through TODO deepfake
-        detection model(s)
+        Loads the PyTorch binary deepfake classifier from the path specified in --neuron.model_path.
+        Processes the incoming ImageSynapse and passed the image to the loaded model for classification.
+        The model is loaded here, rather than in __init__, so that miners may (backup) and overwrite
+        their model file as a means of updating their miner's predictor.
 
         Args:
             synapse (ImageSynapse): The synapse object containing the list of b64 encoded images in the

--- a/neurons/validator.py
+++ b/neurons/validator.py
@@ -30,13 +30,16 @@ from bitmind.constants import DATASET_META
 
 class Validator(BaseValidatorNeuron):
     """
-    Your validator neuron class. You should use this class to define your validator's behavior. In particular, you should replace the forward function with your own logic.
+    The BitMind Validator's `forward` function sends single-image challenges to miners every 30 seconds, where each
+    image has a 50/50 chance of being real or fake. To service this task, the Validator class has two key members -
+    self.real_iamge_dataset and self.random_image_generator. The former is a list of ImageDataset classes, which
+    contain real images. The latter is an ML pipeline that combines an LLM for prompt generation, and a diffusion
+    models that ingest prompts output by this model to produce synthetic iamges.
 
-    This class inherits from the BaseValidatorNeuron class, which in turn inherits from BaseNeuron. The BaseNeuron class takes care of routine tasks such as setting up wallet, subtensor, metagraph, logging directory, parsing config, etc. You can override any of the methods in BaseNeuron if you need to customize the behavior.
-
-    This class provides reasonable default behavior for a validator such as keeping a moving average of the scores of the miners and using them to set weights at the end of each epoch. Additionally, the scores are reset for new hotkeys at the end of each epoch.
+    The BitMind Validator also encapsuluates a ValidatorProxy, which is used to service organic requests from
+    our consumer-facing application. If you wish to participate in this system, run your validator with the
+     --proxy.port argument set to an exposed port on your machine.
     """
-
     def __init__(self, config=None):
         super(Validator, self).__init__(config=config)
 

--- a/neurons/validator.py
+++ b/neurons/validator.py
@@ -31,10 +31,10 @@ from bitmind.constants import DATASET_META
 class Validator(BaseValidatorNeuron):
     """
     The BitMind Validator's `forward` function sends single-image challenges to miners every 30 seconds, where each
-    image has a 50/50 chance of being real or fake. To service this task, the Validator class has two key members -
-    self.real_iamge_dataset and self.random_image_generator. The former is a list of ImageDataset classes, which
-    contain real images. The latter is an ML pipeline that combines an LLM for prompt generation, and a diffusion
-    models that ingest prompts output by this model to produce synthetic iamges.
+    image has a 50/50 chance of being real or fake. In service of this task, the Validator class has two key members -
+    self.real_iamge_datasets and self.random_image_generator. The former is a list of ImageDataset objects, which
+    contain real images. The latter is an ML pipeline that combines an LLM for prompt generation and diffusion
+    models that ingest prompts output by the LLM to produce synthetic iamges.
 
     The BitMind Validator also encapsuluates a ValidatorProxy, which is used to service organic requests from
     our consumer-facing application. If you wish to participate in this system, run your validator with the


### PR DESCRIPTION
- In-flight entertainment PR 
- Finished function headers and explicit typing for arguments and return values for majority of the codebase 
- Moved helper functions out of `image_datset.py` into `utils/data.py`
- Bugfix for an issue where some images in `open-images` have an alpha channel, but their `mode` is not set to `RBGA`. Due to code (which has now been removed) that checked for 'A' in the image's `mode` attribute before converting to `RGB`, the alpha channel wasn't removed and training broke due to a shape mismatch. 