### PR TITLE
Renaming datasets

### DIFF
--- a/bitmind/constants.py
+++ b/bitmind/constants.py
@@ -10,8 +10,8 @@ DATASET_META = {
         {"path": "saitsharipov/CelebA-HQ", "create_splits": True}
     ],
     "fake": [
-        {"path": "bitmind/RealVisXL_V4.0_images", "create_splits": True},
-        {"path": "bitmind/stable-diffusion-xl-base-1.0-images", "create_splits": True},
+        {"path": "bitmind/realvis-xl", "create_splits": True},
+        {"path": "bitmind/stable-diffusion-xl", "create_splits": True},
     ]
 }
 


### PR DESCRIPTION
- making dataset names less of a pain in the ass to type out/remember
  - `bitmind/RealVisXL_V4.0_images` --> `bitmind/realvis-xl`
  - `bitmind/stable-diffusion-xl-base-1.0-images` --> `bitmind/stable-diffusion-xl`
- Lmk if you guys think it'd be better to remove the `xl` as well, but my thoughts were that we may eventually generate images from diff model sizes and prefer to upload them as separate datasets.
- Note that I haven't updated the datasets in huggingface yet, will do so once this is merged