### PR TITLE
W&B Logging Numpy Incompatibility Fix

### DIFF
--- a/bitmind/validator/forward.py
+++ b/bitmind/validator/forward.py
@@ -113,7 +113,7 @@ async def forward(self):
             'data_aug_params': data_aug_params,
             'image_source': source_name,
             'label': label,
-            'miner_uid': miner_uids,
+            'miner_uid': list(miner_uids),
             'pred': responses,
             'correct': [
                 np.round(y_hat) == y


### PR DESCRIPTION
wandb treating numpy arrays as histograms for some reason, so casting to a list