### PR TITLE
Validator Dataset Train Partition

### DIFF
--- a/neurons/validator.py
+++ b/neurons/validator.py
@@ -53,7 +53,7 @@ class Validator(BaseValidatorNeuron):
         
         bt.logging.info("Loading real datasets")
         self.real_image_datasets = [
-            ImageDataset(ds['path'], 'test', ds.get('name', None), ds['create_splits'])
+            ImageDataset(ds['path'], 'train', ds.get('name', None), ds['create_splits'])
             for ds in DATASET_META['real']
         ]
 


### PR DESCRIPTION
- Now that all of our datasets on huggingface are contained in the default 'train' partition, use this partition on validators