### PR TITLE
Vali Proxy Updates

### DIFF
--- a/bitmind/constants.py
+++ b/bitmind/constants.py
@@ -1,7 +1,7 @@
 import os
 
 
-WANDB_PROJECT = 'bitmind'
+WANDB_PROJECT = 'bitmind-subnet'
 WANDB_ENTITY = 'bitmindai'
 
 DATASET_META = {

--- a/neurons/validator.py
+++ b/neurons/validator.py
@@ -47,6 +47,9 @@ class Validator(BaseValidatorNeuron):
 
         bt.logging.info("load_state()")
         self.load_state()
+
+        self.last_responding_miner_uids = []
+        self.validator_proxy = ValidatorProxy(self)
         
         bt.logging.info("init_wandb()")
         self.init_wandb()
@@ -59,8 +62,6 @@ class Validator(BaseValidatorNeuron):
 
         self.synthetic_image_generator = SyntheticImageGenerator(
             prompt_type='annotation', use_random_diffuser=True, diffuser_name=None)
-        self.last_responding_miner_uids = []
-        self.validator_proxy = ValidatorProxy(self)
 
     async def forward(self):
         """

--- a/neurons/validator_proxy.py
+++ b/neurons/validator_proxy.py
@@ -126,7 +126,7 @@ class ValidatorProxy:
 
         metagraph = self.validator.metagraph
         return {
-            'uids': [int(uid) for uid in metagraph.uids],
+            'uids': [str(uid) for uid in metagraph.uids],
             'ranks': [float(r) for r in metagraph.R],
             'incentives': [float(i) for i in metagraph.I],
             'emissions': [float(e) for e in metagraph.E]

--- a/neurons/validator_proxy.py
+++ b/neurons/validator_proxy.py
@@ -126,10 +126,10 @@ class ValidatorProxy:
 
         metagraph = self.validator.metagraph
         return {
-            'uids': metagraph.uids,
-            'ranks': metagraph.R,
-            'incentives': metagraph.I,
-            'emissions': metagraph.E
+            'uids': [int(uid) for uid in metagraph.uids],
+            'ranks': [float(r) for r in metagraph.R],
+            'incentives': [float(i) for i in metagraph.I],
+            'emissions': [float(e) for e in metagraph.E]
         }
 
     async def forward(self, request: Request):


### PR DESCRIPTION
- Fixing `/metagraph` endpoint by casting numpy things to python primitives
- moving vali proxy initialization earlier in validator __init__ for faster startup
- also sneaking in w&b project name update for mainnet