### PR TITLE
Training splits loading fix

### DIFF
--- a/bitmind/utils/data.py
+++ b/bitmind/utils/data.py
@@ -69,6 +69,7 @@ def load_huggingface_dataset(
             return dataset[split]
         return dataset
 
+    # Split data into train, validation, test and return the three splits
     dataset = dataset.shuffle(seed=42)
 
     split_dataset = {}
@@ -80,7 +81,8 @@ def load_huggingface_dataset(
     val_test_split = temp_dataset.train_test_split(test_size=0.5, seed=42)
     split_dataset['validation'] = val_test_split['train']
     split_dataset['test'] = val_test_split['test']
-    return split_dataset[split]
+
+    return split_dataset['train'], split_dataset['validation'], split_dataset['test']
 
 
 def sample_dataset_index_name(image_datasets: list) -> tuple[int, str]:


### PR DESCRIPTION
**Issue Addressed:** Repeated download and data splitting operations when running `base_miner/train_detector.py`. 
**Solution:** Store all splits created by the first initialization of an ImageDataset instance (for each unique HuggingFace source) and avoid initializing any more ImageDataset instances, which would call `load_huggingface_dataset(...)` and trigger downloads/splitting again.
**Changes:**
- Modified `load_huggingface_dataset(...)` in `bitmind/utils/data.py` to return tuple of splits if `create_splits == true`
- Added function in `base_miner/util/data.py` to:

1. Get splits from initializing `ImageDataset`
2. Create new uninitialized instances of `ImageDataset` and assign these instances the data splits, thereby avoiding repeated `load_huggingface_dataset(...)` calls
3. Append these `ImageDataset` objs to return dict