### PR TITLE
Min Compute Validator GPU to 4090

### DIFF
--- a/min_compute.yml
+++ b/min_compute.yml
@@ -36,7 +36,7 @@ compute_spec:
       ram_type: "DDR4"     # RAM type (e.g., DDR4, DDR3, etc.)
 
     storage:
-      min_space: 50           # Minimum free storage space (GB)
+      min_space: 100           # Minimum free storage space (GB)
       recommended_space: 100  # Recommended free storage space (GB)
       type: "SSD"             # Preferred storage type (e.g., SSD, HDD)
       min_iops: 1000          # Minimum I/O operations per second (if applicable)
@@ -59,10 +59,9 @@ compute_spec:
       required: True                         # Does the application require a GPU?
       min_vram: 24                           # Minimum GPU VRAM (GB)
       recommended_vram: 24                   # Recommended GPU VRAM (GB)
-      cuda_cores: 1024                       # Minimum number of CUDA cores (if applicable)
       min_compute_capability: 6.0            # Minimum CUDA compute capability
       recommended_compute_capability: 7.0    # Recommended CUDA compute capability
-      recommended_gpu: "NVIDIA RTX 3090"     # provide a recommended GPU to purchase/rent
+      recommended_gpu: "NVIDIA RTX 4090"     # provide a recommended GPU to purchase/rent
 
     memory:
       min_ram: 32          # Minimum RAM (GB)


### PR DESCRIPTION
Validators can currently get away with a 3090, updating to 4090 for some buffer for future updates that may put more of a strain on the gpu