### PR TITLE
Validator Caption/Image Resampling

### DIFF
--- a/bitmind/validator/forward.py
+++ b/bitmind/validator/forward.py
@@ -67,7 +67,7 @@ async def forward(self):
 
         wandb_data['dataset'] = source_dataset
         wandb_data['image_index'] = idx[0]
-        wandb_data['image_id'] = sample['id']
+        wandb_data['image_name'] = sample['id']
 
     else:
         label = 1
@@ -90,7 +90,7 @@ async def forward(self):
 
                 wandb_data['model'] = self.synthetic_image_generator.diffuser_name
                 wandb_data['source_dataset'] = source_dataset
-                wandb_data['source_image_id'] = images_to_caption[0]['id']
+                wandb_data['source_image_name'] = images_to_caption[0]['id']
                 wandb_data['source_image_index'] = image_indexes[0]
                 wandb_data['image'] = wandb.Image(sample['image'])
                 wandb_data['prompt'] = sample['prompt']

--- a/bitmind/validator/forward.py
+++ b/bitmind/validator/forward.py
@@ -94,7 +94,7 @@ async def forward(self):
                 wandb_data['source_image_index'] = image_indexes[0]
                 wandb_data['image'] = wandb.Image(sample['image'])
                 wandb_data['prompt'] = sample['prompt']
-                if not np.isnan(wandb_data['image']):
+                if not np.any(np.isnan(sample['image'])):
                     break
 
                 bt.logging.warning("NaN encountered in prompt/image generation, retrying...")

--- a/bitmind/validator/forward.py
+++ b/bitmind/validator/forward.py
@@ -62,10 +62,12 @@ async def forward(self):
         label = 0
         real_dataset_index, source_dataset = sample_dataset_index_name(self.real_image_datasets)
         real_dataset = self.real_image_datasets[real_dataset_index]
-        sample = real_dataset.sample(k=1)[0][0]  # {'image': PIL Image ,'id': int}
+        samples, idx = real_dataset.sample(k=1)  # {'image': PIL Image ,'id': int}
+        sample = samples[0]
 
         wandb_data['dataset'] = source_dataset
-        wandb_data['image_index'] = sample['id']
+        wandb_data['image_index'] = idx[0]
+        wandb_data['image_id'] = sample['id']
 
     else:
         label = 1
@@ -76,15 +78,16 @@ async def forward(self):
             # sample image(s) from real dataset for captioning
             real_dataset_index, source_dataset = sample_dataset_index_name(self.real_image_datasets)
             real_dataset = self.real_image_datasets[real_dataset_index]
-            images_to_caption = real_dataset.sample(k=1)[0]  # [{'image': PIL Image ,'id': int}, ...]
+            images_to_caption, image_indexes = real_dataset.sample(k=1)  # [{'image': PIL Image ,'id': int}, ...]
 
             # generate captions for the real images, then synthetic images from these captions
             sample = self.synthetic_image_generator.generate(
-                k=1, real_images=images_to_caption)[0]  # {'prompt': str, 'image': PIL Image ,'id': int}
+                k=1, real_images=images_to_caption[0])[0]  # {'prompt': str, 'image': PIL Image ,'id': int}
 
             wandb_data['model'] = self.synthetic_image_generator.diffuser_name
             wandb_data['source_dataset'] = source_dataset
-            wandb_data['source_image_index'] = images_to_caption[0]['id']
+            wandb_data['source_image_id'] = images_to_caption[0]['id']
+            wandb_data['source_image_index'] = image_indexes[0]
             wandb_data['image'] = wandb.Image(sample['image'])
             wandb_data['prompt'] = sample['prompt']
 

--- a/neurons/validator.py
+++ b/neurons/validator.py
@@ -89,14 +89,19 @@ class Validator(BaseValidatorNeuron):
 
         # Initialize the wandb run for the single project
         print("Initializing W&B")
-        run = wandb.init(
-            name=run_name,
-            project=WANDB_PROJECT,
-            entity=WANDB_ENTITY,
-            config=self.config,
-            dir=self.config.full_path,
-            reinit=True
-        )
+        try:
+            run = wandb.init(
+                name=run_name,
+                project=WANDB_PROJECT,
+                entity=WANDB_ENTITY,
+                config=self.config,
+                dir=self.config.full_path,
+                reinit=True
+            )
+        except wandb.UsageError as e:
+            bt.logging.warning(e)
+            bt.logging.warning("Did you run wandb login?")
+            return
 
         # Sign the run to ensure it's from the correct hotkey
         signature = self.wallet.hotkey.sign(run.id.encode()).hex()


### PR DESCRIPTION
- Fixing `image_index` field for wandb logging, it used to be populated with the `id` field returned from the generation step, but we want this to simply be the image's dataset index
- Also adding retries in case image/prompt generation produces any NaN values. Will be doing a deeper dive to find root causes, but for now this will handle NaNs that appear for any reason
- Also adding a try/except for wandb init, this handles the case that a validator turns on wandb logging but doesn't log in