### PR TITLE
Fix weight set edge case

### DIFF
--- a/bitmind/base/miner.py
+++ b/bitmind/base/miner.py
@@ -125,6 +125,7 @@ class BaseMinerNeuron(BaseNeuron):
                 # Sync metagraph and potentially set weights.
                 self.sync()
                 self.step += 1
+                time.sleep(60)
 
         # If someone intentionally stops the miner, it'll safely terminate operations.
         except KeyboardInterrupt:

--- a/bitmind/base/utils/weight_utils.py
+++ b/bitmind/base/utils/weight_utils.py
@@ -157,6 +157,9 @@ def process_weights_for_netuid(
 
     # Find all non zero weights.
     non_zero_weight_idx = np.argwhere(weights > 0).squeeze()
+    if non_zero_weight_idx.ndim == 0:
+        non_zero_weight_idx = non_zero_weight_idx.reshape((1,))
+
     non_zero_weight_uids = uids[non_zero_weight_idx]
     non_zero_weights = weights[non_zero_weight_idx]
     if non_zero_weights.size == 0 or metagraph.n < min_allowed_weights:

--- a/docs/Mining.md
+++ b/docs/Mining.md
@@ -32,7 +32,9 @@ chmod +x install_system_deps.sh
 ```
 
 We recommend using a Conda virtual environment to install the necessary Python packages.<br>
-You can set up Conda with this [quick command-line install](https://docs.anaconda.com/free/miniconda/#quick-command-line-install), and create a virtual environment with this command:
+You can set up Conda with this [quick command-line install](https://docs.anaconda.com/free/miniconda/#quick-command-line-install). Note that after you run the last commands in the miniconda setup process, you'll be prompted to start a new shell session to complete the initialization. 
+
+With miniconda installed, you can create a virtual environment with this command:
 
 ```bash
 conda create -y -n bitmind python=3.10 ipython jupyter ipykernel

--- a/start_validator.py
+++ b/start_validator.py
@@ -15,7 +15,7 @@ def update_and_restart(pm2_name, wallet_name, wallet_hotkey, port, network, addr
 
     vali_start_command = [
         "pm2", "start", "neurons/validator.py", "--interpreter", "python3", "--name", pm2_name, "--", "--wallet.name", wallet_name, "--wallet.hotkey", wallet_hotkey,
-        "--netuid", "168", "--subtensor.network", network, "--axon.port", port
+        "--netuid", "34", "--subtensor.network", network, "--axon.port", port
     ]
     if network == 'finney' or address != default_address:
         vali_start_command += ["--subtensor.chain_endpoint", address]


### PR DESCRIPTION
- Casting single valued weight vector to a numpy array. This only occurs when there's 1 miner responding correctly (i.e. it's a testnet edge case)
- Also adding a sleep to the miner run loop to reduce frequency of metagraph resync while we debug the `should_resync_metagraph` function