### PR TITLE
Fix Weight Setting Edge Case

### DIFF
--- a/bitmind/base/miner.py
+++ b/bitmind/base/miner.py
@@ -125,6 +125,7 @@ class BaseMinerNeuron(BaseNeuron):
                 # Sync metagraph and potentially set weights.
                 self.sync()
                 self.step += 1
+                time.sleep(60)
 
         # If someone intentionally stops the miner, it'll safely terminate operations.
         except KeyboardInterrupt:

--- a/bitmind/base/utils/weight_utils.py
+++ b/bitmind/base/utils/weight_utils.py
@@ -157,6 +157,9 @@ def process_weights_for_netuid(
 
     # Find all non zero weights.
     non_zero_weight_idx = np.argwhere(weights > 0).squeeze()
+    if non_zero_weight_idx.ndim == 0:
+        non_zero_weight_idx = non_zero_weight_idx.reshape((1,))
+
     non_zero_weight_uids = uids[non_zero_weight_idx]
     non_zero_weights = weights[non_zero_weight_idx]
     if non_zero_weights.size == 0 or metagraph.n < min_allowed_weights:


### PR DESCRIPTION
Fixing this edge case:
- in weight_utils.process_weights_for_netuid , non-zero weight indices are extracted by calling np.argwhere(weights > 0).squeeze(). 
- In the case where there is only a single weight with a non-zero value, this returns an array scalar (which is an unsized object, i.e. you cannot call len on it).
- The resulting variable non_zero_weight_idx is used to index into uids and weights, which again produces an array scaler 
- Downstream code calls len on non_zero_weights, which fails in the case of it being an array scaler 

Also adding a sleep to reduce frequency of miner metagraph resync while we debug `should_resync_metagraph`