### PR TITLE
Autoupdate Python/Pip Binaries

### DIFF
--- a/autoupdate_miner_steps.sh
+++ b/autoupdate_miner_steps.sh
@@ -4,6 +4,6 @@
 # THIS FILE CONTAINS THE STEPS NEEDED TO AUTOMATICALLY UPDATE THE REPO
 # THIS FILE ITSELF MAY CHANGE FROM UPDATE TO UPDATE, SO WE CAN DYNAMICALLY FIX ANY ISSUES
 
-conda activate bitmind
-pip install -e .
+echo $CONDA_PREFIX
+$CONDA_PREFIX/bin/pip install -e .
 echo "Autoupdate steps complete :)"

--- a/autoupdate_validator_steps.sh
+++ b/autoupdate_validator_steps.sh
@@ -4,7 +4,7 @@
 # THIS FILE CONTAINS THE STEPS NEEDED TO AUTOMATICALLY UPDATE THE REPO
 # THIS FILE ITSELF MAY CHANGE FROM UPDATE TO UPDATE, SO WE CAN DYNAMICALLY FIX ANY ISSUES
 
-conda activate bitmind
-pip install -e .
-python bitmind/download_data.py
+echo $CONDA_PREFIX
+$CONDA_PREFIX/bin/pip install -e .
+$CONDA_PREFIX/bin/python bitmind/download_data.py
 echo "Autoupdate steps complete :)"


### PR DESCRIPTION
- Running conda activate in a shell script gives a warning, so instead using $CONDA_PREFIX to select the correct python and pip binaries in autoupdate scripts