### PR TITLE
UCF backbone overwrite

### DIFF
--- a/base_miner/UCF/config/ucf.yaml
+++ b/base_miner/UCF/config/ucf.yaml
@@ -2,7 +2,7 @@
 log_dir: ../debug_logs/ucf
 
 # model setting
-pretrained: ../weights/xception_best.pth   # path to a pre-trained model, if using one
+pretrained: ../weights/xception-best.pth   # path to a pre-trained model, if using one
 model_name: ucf   # model name
 backbone_name: xception  # backbone name
 encoder_feat_dim: 512  # feature dimension of the backbone

--- a/base_miner/UCF/train_detector.py
+++ b/base_miner/UCF/train_detector.py
@@ -440,7 +440,7 @@ def main():
     ensure_backbone_is_available(
         logger=logger,
         model_filename=config['pretrained'].split('/')[-1],
-        hugging_face_repo_name='bitmind/' + config['model_name']
+        hugging_face_repo_name='bitmind/bm-ucf'
     )
     
     # prepare the model (detector)

--- a/base_miner/deepfake_detectors/configs/ucf.yaml
+++ b/base_miner/deepfake_detectors/configs/ucf.yaml
@@ -2,4 +2,3 @@
 hf_repo: 'bitmind/bm-ucf'  # Hugging Face repository for downloading model files
 train_config: 'bm-general-config.yaml'  # pre-trained configuration file in HuggingFace
 weights: 'bm-general.pth'  # UCF model checkpoint in HuggingFace
-backbone_weights: 'xception-best.pth'  # backbone model checkpoint in HuggingFace

--- a/base_miner/deepfake_detectors/configs/ucf_face.yaml
+++ b/base_miner/deepfake_detectors/configs/ucf_face.yaml
@@ -2,4 +2,3 @@
 hf_repo: 'bitmind/bm-ucf'  # Hugging Face repository for downloading model files
 train_config: 'bm-faces-config.yaml'  # pre-trained configuration file in HuggingFace
 weights: 'bm-faces.pth'  # UCF model checkpoint in HuggingFace
-backbone_weights: 'xception-best.pth'  # backbone model checkpoint in HuggingFace

--- a/base_miner/deepfake_detectors/ucf_detector.py
+++ b/base_miner/deepfake_detectors/ucf_detector.py
@@ -86,7 +86,7 @@ class UCFDetector(DeepfakeDetector):
         self.ensure_weights_are_available(self.backbone_weights)
         self.train_config['pretrained'] =  '/'.join([WEIGHTS_DIR, self.backbone_weights])
         model_class = DETECTOR[self.train_config['model_name']]
-        #bt.logging.info(f"Loaded config from training run: {self.train_config}")
+        bt.logging.info(f"Loaded config from training run: {self.train_config}")
         self.model = model_class(self.train_config).to(self.device)
         self.model.eval()
         weights_path = Path(WEIGHTS_DIR) / self.weights

--- a/base_miner/deepfake_detectors/ucf_detector.py
+++ b/base_miner/deepfake_detectors/ucf_detector.py
@@ -84,8 +84,9 @@ class UCFDetector(DeepfakeDetector):
         self.init_seed()
         self.ensure_weights_are_available(self.weights)
         self.ensure_weights_are_available(self.backbone_weights)
+        self.train_config['pretrained'] =  '/'.join([WEIGHTS_DIR, self.backbone_weights])
         model_class = DETECTOR[self.train_config['model_name']]
-        bt.logging.info(f"Loaded config from training run: {self.train_config}")
+        #bt.logging.info(f"Loaded config from training run: {self.train_config}")
         self.model = model_class(self.train_config).to(self.device)
         self.model.eval()
         weights_path = Path(WEIGHTS_DIR) / self.weights

--- a/base_miner/deepfake_detectors/ucf_detector.py
+++ b/base_miner/deepfake_detectors/ucf_detector.py
@@ -83,8 +83,7 @@ class UCFDetector(DeepfakeDetector):
         self.init_cudnn()
         self.init_seed()
         self.ensure_weights_are_available(self.weights)
-        self.ensure_weights_are_available(self.backbone_weights)
-        self.train_config['pretrained'] =  '/'.join([WEIGHTS_DIR, self.backbone_weights])
+        self.ensure_weights_are_available(self.train_config['pretrained'].split('/')[-1])
         model_class = DETECTOR[self.train_config['model_name']]
         bt.logging.info(f"Loaded config from training run: {self.train_config}")
         self.model = model_class(self.train_config).to(self.device)

--- a/base_miner/deepfake_detectors/unit_tests/run_all_unit_tests.py
+++ b/base_miner/deepfake_detectors/unit_tests/run_all_unit_tests.py
@@ -1,0 +1,18 @@
+import os
+import subprocess
+
+def run_all_py_scripts(directory):
+    # List all files in the directory
+    for filename in os.listdir(directory):
+        # Check if the file ends with .py and is not this script itself
+        if filename.endswith('.py') and filename != os.path.basename(__file__):
+            # Full path of the python file
+            filepath = os.path.join(directory, filename)
+            print(f"Running {filename}...")
+            
+            # Run the script using subprocess
+            subprocess.run(['python', filepath])
+
+if __name__ == "__main__":
+    # Run all python files in the current directory
+    run_all_py_scripts(os.getcwd())

--- a/base_miner/deepfake_detectors/unit_tests/test_camo_detector.py
+++ b/base_miner/deepfake_detectors/unit_tests/test_camo_detector.py
@@ -26,8 +26,7 @@ class TestCAMODetector(unittest.TestCase):
 
     def test_load_gates(self):
         """Test if the models load properly with the given weight paths."""
-        self.assertIsNotNone(self.camo_detector.gate, "Gate should not be None")
-        self.assertIsNotNone(self.camo_detector.gate.gates, "GatingMechanism gates not be None")
+        self.assertIsNotNone(self.camo_detector.gating_mechanism, "GatingMechanism gates not be None")
 
     def test_call(self):
         """Test the __call__ method for inference on a given image."""

--- a/base_miner/deepfake_detectors/unit_tests/test_registry.py
+++ b/base_miner/deepfake_detectors/unit_tests/test_registry.py
@@ -11,7 +11,7 @@ sys.path.append(parent_directory)
 class TestDetectorRegistry(unittest.TestCase):
     
     def test_registry_contents(self):
-        from detector_registry import Registry
+        from base_miner.registry import Registry
         detector_registry = Registry()
         # Check if the registry has the expected keys (class names or custom names)
         registered_keys = list(detector_registry.data.keys())
@@ -25,7 +25,7 @@ class TestDetectorRegistry(unittest.TestCase):
         self.assertEqual(len(registered_keys), 0, "There should be no registered detectors.")
 
     def test_registry_contents_after_import(self):
-        from base_miner.deepfake_detectors import DETECTOR_REGISTRY
+        from base_miner import DETECTOR_REGISTRY
         # Check if the registry has the expected keys (class names or custom names)
         registered_keys = list(DETECTOR_REGISTRY.data.keys())
         

--- a/base_miner/deepfake_detectors/unit_tests/test_ucf_detector.py
+++ b/base_miner/deepfake_detectors/unit_tests/test_ucf_detector.py
@@ -40,9 +40,7 @@ class TestUCFDetector(unittest.TestCase):
     def test_model_loading(self):
         """Test if the model is loaded properly."""
         self.assertIsNotNone(self.ucf_detector.model, "Generalist model should not be None")
-        self.assertIsNone(self.ucf_detector.gate, "Generalist gate should be None")
         self.assertIsNotNone(self.ucf_detector_face.model, "Face model should not be None")
-        self.assertIsNotNone(self.ucf_detector_face.gate, "Face gate should not be None")
 
     def test_infer_general(self):
         """Test a basic inference to ensure model outputs are correct."""

--- a/base_miner/deepfake_detectors/unit_tests/test_ucf_detector.py
+++ b/base_miner/deepfake_detectors/unit_tests/test_ucf_detector.py
@@ -30,11 +30,11 @@ class TestUCFDetector(unittest.TestCase):
         """Test if the weights are checked and downloaded if missing."""
         self.assertTrue((Path(WEIGHTS_DIR) / self.ucf_detector.weights).exists(),
                         "Model weights should be available after initialization.")
-        self.assertTrue((Path(WEIGHTS_DIR) / self.ucf_detector.backbone_weights).exists(),
+        self.assertTrue((Path(WEIGHTS_DIR) / self.ucf_detector.train_config['pretrained'].split('/')[-1]).exists(),
                         "Backbone weights should be available after initialization.")
         self.assertTrue((Path(WEIGHTS_DIR) / self.ucf_detector_face.weights).exists(),
                         "Face model weights should be available after initialization.")
-        self.assertTrue((Path(WEIGHTS_DIR) / self.ucf_detector_face.backbone_weights).exists(),
+        self.assertTrue((Path(WEIGHTS_DIR) / self.ucf_detector_face.train_config['pretrained'].split('/')[-1]).exists(),
                         "Face backbone weights should be available after initialization.")
 
     def test_model_loading(self):


### PR DESCRIPTION
- Backbone weights now overwritten to the path in detector config, instead of the pretrained backbone weights path from training config
- Updated all detector ad hoc unit tests and added a script that runs all detector tests: `base_miner/deepfake_detectors/unit_tests/run_all_unit_tests.py`
 - These tests run detector initialization, config loading, model loading, and inference calls for each DeepfakeDetector subclass 