### PR TITLE
Expose VALIDATOR_PROXY_PORT Arg

### DIFF
--- a/bitmind/__init__.py
+++ b/bitmind/__init__.py
@@ -18,7 +18,7 @@
 # DEALINGS IN THE SOFTWARE.
 
 
-__version__ = "1.2.4"
+__version__ = "1.2.5"
 version_split = __version__.split(".")
 __spec_version__ = (
     (1000 * int(version_split[0]))

--- a/setup_validator_env.sh
+++ b/setup_validator_env.sh
@@ -26,8 +26,10 @@ SUBTENSOR_CHAIN_ENDPOINT=wss://entrypoint-finney.opentensor.ai:443
 WALLET_NAME=default
 WALLET_HOTKEY=default
 
+# Note: If you're using RunPod, you must select a port >= 70000 for symmetric mapping
 # Validator Port Setting:
 VALIDATOR_AXON_PORT=8092
+VALIDATOR_PROXY_PORT=10913
 
 # API Keys:
 WANDB_API_KEY=your_wandb_api_key_here

--- a/start_validator.sh
+++ b/start_validator.sh
@@ -5,6 +5,9 @@ set -a
 source validator.env
 set +a
 
+# Set VALIDATOR_PROXY_PORT with a default of 10913 if not already set
+: ${VALIDATOR_PROXY_PORT:=10913}
+
 # Login to Weights & Biases
 if ! wandb login $WANDB_API_KEY; then
   echo "Failed to login to Weights & Biases with the provided API key."
@@ -36,4 +39,5 @@ pm2 start neurons/validator.py --name bitmind_validator -- \
   --subtensor.chain_endpoint $SUBTENSOR_CHAIN_ENDPOINT \
   --wallet.name $WALLET_NAME \
   --wallet.hotkey $WALLET_HOTKEY \
-  --axon.port $VALIDATOR_AXON_PORT
+  --axon.port $VALIDATOR_AXON_PORT \
+  --proxy.port $VALIDATOR_PROXY_PORT


### PR DESCRIPTION
- Adding `VALIDATOR_PROXY_PORT` to `validator.env` args to make this more easily configurable for validators on containerized service with access to limited port ranges 