### PR TITLE
Sampling edge case fix

### DIFF
--- a/bitmind/__init__.py
+++ b/bitmind/__init__.py
@@ -18,7 +18,7 @@
 # DEALINGS IN THE SOFTWARE.
 
 
-__version__ = "1.2.5"
+__version__ = "1.2.6"
 version_split = __version__.split(".")
 __spec_version__ = (
     (1000 * int(version_split[0]))

--- a/bitmind/validator/forward.py
+++ b/bitmind/validator/forward.py
@@ -45,7 +45,7 @@ def sample_random_real_image(datasets, total_images, retries=10):
 
 def sample_real_image(datasets, index):
     cumulative_sizes = np.cumsum([len(ds) for ds in datasets])
-    source_index = np.searchsorted(cumulative_sizes, index % (cumulative_sizes[-1]))
+    source_index = np.searchsorted(cumulative_sizes - 1, index % (cumulative_sizes[-1]))
     source = datasets[source_index]
     valid_index = index - (cumulative_sizes[source_index - 1] if source_index > 0 else 0)
     return source, valid_index


### PR DESCRIPTION
Edge case wherein if the sampled index == the length of a dataset, resulting localized index would provide an index error. Specifically, this line:
```    source_index = np.searchsorted(cumulative_sizes, index % (cumulative_sizes[-1]))
```
with cumulative sizes exactly equal to the length of one of the datasets, the source index and localized image index would both be off by 1.