### PR TITLE
Difficulty levels

### DIFF
--- a/bitmind/__init__.py
+++ b/bitmind/__init__.py
@@ -18,7 +18,7 @@
 # DEALINGS IN THE SOFTWARE.
 
 
-__version__ = "1.2.5"
+__version__ = "1.2.6"
 version_split = __version__.split(".")
 __spec_version__ = (
     (1000 * int(version_split[0]))

--- a/bitmind/__init__.py
+++ b/bitmind/__init__.py
@@ -18,7 +18,7 @@
 # DEALINGS IN THE SOFTWARE.
 
 
-__version__ = "1.2.6"
+__version__ = "1.2.7"
 version_split = __version__.split(".")
 __spec_version__ = (
     (1000 * int(version_split[0]))

--- a/bitmind/image_transforms.py
+++ b/bitmind/image_transforms.py
@@ -1,3 +1,5 @@
+import math
+import random
 from PIL import Image
 import torchvision.transforms as transforms
 import numpy as np
@@ -7,7 +9,7 @@ import cv2
 from bitmind.constants import TARGET_IMAGE_SIZE
 
 
-def CenterCrop():
+def center_crop():
     def fn(img):
         m = min(img.size)
         return transforms.CenterCrop(m)(img)
@@ -71,28 +73,181 @@ class ConvertToRGB:
         return img
 
 
-class CLAHE:
-    def __call__(self, image, clip_limit=1.0, tile_grid_size=(8, 8)):
-        # Convert PIL image to NumPy array
-        image_np = np.array(image)
+# DeeperForensics Distortion Functions
 
-        # Create a CLAHE object
+def get_distortion_parameter(distortion_type, level):
+    """Get distortion parameter based on type and level."""
+    param_dict = {
+        'CS': [0.4, 0.3, 0.2, 0.1, 0.0],  # smaller, worse
+        'CC': [0.85, 0.725, 0.6, 0.475, 0.35],  # smaller, worse
+        'BW': [16, 32, 48, 64, 80],  # larger, worse
+        'GNC': [0.001, 0.002, 0.005, 0.01, 0.05],  # larger, worse
+        'GB': [7, 9, 13, 17, 21],  # larger, worse
+        'JPEG': [2, 3, 4, 5, 6]  # larger, worse
+    }
+    return param_dict[distortion_type][level - 1]
+
+
+def get_distortion_function(distortion_type):
+    """Get distortion function based on type."""
+    func_dict = {
+        'CS': color_saturation,
+        'CC': color_contrast,
+        'BW': block_wise,
+        'GNC': gaussian_noise_color,
+        'GB': gaussian_blur,
+        'JPEG': jpeg_compression
+    }
+    return func_dict[distortion_type]
+
+
+def rgb_to_bgr(tensor_img):
+    """Convert a PyTorch tensor image from RGB to BGR format.
+    
+    Args:
+        tensor_img: Tensor in format (C, H, W)
+    """
+    if tensor_img.shape[0] == 3:
+        tensor_img = tensor_img[[2, 1, 0], ...]
+    return tensor_img
+
+
+def bgr_to_rgb(tensor_img):
+    """Convert a PyTorch tensor image from BGR to RGB format.
+    
+    Args:
+        tensor_img: Tensor in format (C, H, W) with values in [0, 1]
+    """
+    if tensor_img.shape[0] == 3:
+        tensor_img = tensor_img[[2, 1, 0], ...]
+    return tensor_img
+
+
+def bgr2ycbcr(img_bgr):
+    """Convert BGR image to YCbCr color space."""
+    img_bgr = img_bgr.astype(np.float32)
+    img_ycrcb = cv2.cvtColor(img_bgr, cv2.COLOR_BGR2YCR_CB)
+    img_ycbcr = img_ycrcb[:, :, (0, 2, 1)].astype(np.float32)
+    img_ycbcr[:, :, 0] = (img_ycbcr[:, :, 0] * (235 - 16) + 16) / 255.0
+    img_ycbcr[:, :, 1:] = (img_ycbcr[:, :, 1:] * (240 - 16) + 16) / 255.0
+    return img_ycbcr
+
+
+def ycbcr2bgr(img_ycbcr):
+    """Convert YCbCr image to BGR color space."""
+    img_ycbcr = img_ycbcr.astype(np.float32)
+    img_ycbcr[:, :, 0] = (img_ycbcr[:, :, 0] * 255.0 - 16) / (235 - 16)
+    img_ycbcr[:, :, 1:] = (img_ycbcr[:, :, 1:] * 255.0 - 16) / (240 - 16)
+    img_ycrcb = img_ycbcr[:, :, (0, 2, 1)].astype(np.float32)
+    img_bgr = cv2.cvtColor(img_ycrcb, cv2.COLOR_YCR_CB2BGR)
+    return img_bgr
+
+
+def color_saturation(img, param):
+    """Apply color saturation distortion."""
+    ycbcr = bgr2ycbcr(img)
+    ycbcr[:, :, 1] = 0.5 + (ycbcr[:, :, 1] - 0.5) * param
+    ycbcr[:, :, 2] = 0.5 + (ycbcr[:, :, 2] - 0.5) * param
+    img = ycbcr2bgr(ycbcr).astype(np.uint8)
+    return img
+
+
+def color_contrast(img, param):
+    """Apply color contrast distortion."""
+    img = img.astype(np.float32) * param
+    return img.astype(np.uint8)
+
+
+def block_wise(img, param):
+    """Apply block-wise distortion."""
+    width = 8
+    block = np.ones((width, width, 3)).astype(int) * 128
+    param = min(img.shape[0], img.shape[1]) // 256 * param
+    for _ in range(param):
+        r_w = random.randint(0, img.shape[1] - 1 - width)
+        r_h = random.randint(0, img.shape[0] - 1 - width)
+        img[r_h:r_h + width, r_w:r_w + width, :] = block
+    return img
+
+
+def gaussian_noise_color(img, param):
+    """Apply colored Gaussian noise."""
+    ycbcr = bgr2ycbcr(img) / 255
+    size_a = ycbcr.shape
+    b = (ycbcr + math.sqrt(param) * np.random.randn(size_a[0], size_a[1], size_a[2])) * 255
+    b = ycbcr2bgr(b)
+    return np.clip(b, 0, 255).astype(np.uint8)
+
+
+def gaussian_blur(img, param):
+    """Apply Gaussian blur."""
+    return cv2.GaussianBlur(img, (param, param), param * 1.0 / 6)
+
+
+def jpeg_compression(img, param):
+    """Apply JPEG compression distortion."""
+    h, w, _ = img.shape
+    s_h = h // param
+    s_w = w // param
+    img = cv2.resize(img, (s_w, s_h))
+    return cv2.resize(img, (w, h))
+
+
+class ApplyDeeperForensicsDistortion:
+    """Wrapper for applying DeeperForensics distortions."""
+    
+    def __init__(self, distortion_type, level_min=0, level_max=3):
+        self.distortion_type = distortion_type
+        self.level_min = level_min
+        self.level_max = level_max
+
+    def __call__(self, img):
+        self.level = random.randint(self.level_min, self.level_max)
+        if self.level > 0:
+            self.distortion_param = get_distortion_parameter(self.distortion_type, self.level)
+            self.distortion_func = get_distortion_function(self.distortion_type)
+        else:
+            self.distortion_func = None
+            self.distortion_param = None
+
+        if not self.distortion_func:
+            return img
+
+        if isinstance(img, torch.Tensor):
+            img = rgb_to_bgr(img)
+            img = img.permute(1, 2, 0).cpu().numpy()
+            img = (img * 255).astype(np.uint8)
+
+        img = self.distortion_func(img, self.distortion_param)
+
+        if isinstance(img, np.ndarray):
+            img = torch.from_numpy(img.astype(np.float32) / 255.0)
+            img = img.permute(2, 0, 1)
+            img = bgr_to_rgb(img)
+
+        return img
+
+
+class CLAHE:
+    """Contrast Limited Adaptive Histogram Equalization."""
+    
+    def __call__(self, image, clip_limit=1.0, tile_grid_size=(8, 8)):
+        image_np = np.array(image)
         clahe = cv2.createCLAHE(clipLimit=clip_limit, tileGridSize=tile_grid_size)
 
-        # Apply CLAHE to each channel separately if it's a color image
-        if len(image_np.shape) == 3:  # Color image
+        if len(image_np.shape) == 3:
             channels = cv2.split(image_np)
             clahe_channels = [clahe.apply(ch) for ch in channels]
             clahe_image_np = cv2.merge(clahe_channels)
-        else:  # Grayscale image
+        else:
             clahe_image_np = clahe.apply(image_np)
 
-        # Convert back to PIL image
-        clahe_image = Image.fromarray(clahe_image_np)
+        return Image.fromarray(clahe_image_np)
 
-        return clahe_image
 
 class ComposeWithParams:
+    """Compose multiple transforms with parameter tracking."""
+    
     def __init__(self, transforms):
         self.transforms = transforms
         self.params = {}
@@ -105,22 +260,21 @@ class ComposeWithParams:
             RandomRotationWithParams: 'RandomRotation'
         }
 
-        for t in self.transforms:
-            img = t(img)
-            if type(t) in transform_params:
-                self.params[transform_params[type(t)]] = t.params
+        for transform in self.transforms:
+            img = transform(img)
+            if type(transform) in transform_params:
+                self.params[transform_params[type(transform)]] = transform.params
         return img
 
 
-# transforms to prepare an image for the base miner
+# Transform configurations
 base_transforms = transforms.Compose([
     ConvertToRGB(),
-    CenterCrop(),
+    center_crop(),
     transforms.Resize(TARGET_IMAGE_SIZE),
     transforms.ToTensor()
 ])
 
-# data augmentation
 random_aug_transforms = ComposeWithParams([
     ConvertToRGB(),
     transforms.ToTensor(),
@@ -132,9 +286,37 @@ random_aug_transforms = ComposeWithParams([
 
 ucf_transforms = transforms.Compose([
     ConvertToRGB(),
-    CenterCrop(),
+    center_crop(),
     transforms.Resize(TARGET_IMAGE_SIZE),
     CLAHE(),
     transforms.ToTensor(),
     transforms.Normalize(mean=[0.485, 0.456, 0.406], std=[0.229, 0.224, 0.225])
+])
+
+# Medium difficulty transforms with mild distortions
+random_aug_transforms_medium = ComposeWithParams([
+    ConvertToRGB(),
+    transforms.ToTensor(),
+    RandomRotationWithParams(20, interpolation=transforms.InterpolationMode.BILINEAR),
+    RandomResizedCropWithParams(TARGET_IMAGE_SIZE, scale=(0.2, 1.0), ratio=(1.0, 1.0)),
+    RandomHorizontalFlipWithParams(),
+    RandomVerticalFlipWithParams(),
+    ApplyDeeperForensicsDistortion('CS', level_min=1, level_max=1),
+    ApplyDeeperForensicsDistortion('CC', level_min=1, level_max=1),
+    ApplyDeeperForensicsDistortion('JPEG', level_min=1, level_max=1)
+])
+
+# Hard difficulty transforms with more severe distortions
+random_aug_transforms_hard = ComposeWithParams([
+    ConvertToRGB(),
+    transforms.ToTensor(), 
+    RandomRotationWithParams(20, interpolation=transforms.InterpolationMode.BILINEAR),
+    RandomResizedCropWithParams(TARGET_IMAGE_SIZE, scale=(0.2, 1.0), ratio=(1.0, 1.0)),
+    RandomHorizontalFlipWithParams(),
+    RandomVerticalFlipWithParams(),
+    ApplyDeeperForensicsDistortion('CS', level_min=1, level_max=2),
+    ApplyDeeperForensicsDistortion('CC', level_min=1, level_max=2), 
+    ApplyDeeperForensicsDistortion('JPEG', level_min=1, level_max=2),
+    ApplyDeeperForensicsDistortion('GNC', level_min=1, level_max=2),
+    ApplyDeeperForensicsDistortion('GB', level_min=1, level_max=2)
 ])

--- a/bitmind/validator/forward.py
+++ b/bitmind/validator/forward.py
@@ -30,7 +30,7 @@ from bitmind.utils.uids import get_random_uids
 from bitmind.utils.data import sample_dataset_index_name
 from bitmind.protocol import prepare_image_synapse
 from bitmind.validator.reward import get_rewards
-from bitmind.image_transforms import random_aug_transforms, base_transforms
+from bitmind.image_transforms import apply_augmentation_by_level
 
 
 def sample_random_real_image(datasets, total_images, retries=10):
@@ -127,12 +127,8 @@ async def forward(self):
             raise NotImplementedError
 
     image = sample['image']
-    if np.random.rand() > 0.25:
-        image = random_aug_transforms(image)
-        data_aug_params = random_aug_transforms.params
-    else:
-        image = base_transforms(image)
-        data_aug_params = {}
+    
+    image, level, data_aug_params = apply_augmentation_by_level(image)
 
     bt.logging.info(f"Querying {len(miner_uids)} miners...")
     axons = [self.metagraph.axons[uid] for uid in miner_uids]
@@ -167,6 +163,7 @@ async def forward(self):
     wandb_data['miner_uids'] = list(miner_uids)
     wandb_data['miner_hotkeys'] = list([axon.hotkey for axon in axons])
     wandb_data['predictions'] = responses
+    wandb_data['data_aug_level'] = level
     wandb_data['correct'] = [
         np.round(y_hat) == y
         for y_hat, y in zip(responses, [label] * len(responses))

--- a/bitmind/validator/forward.py
+++ b/bitmind/validator/forward.py
@@ -45,7 +45,7 @@ def sample_random_real_image(datasets, total_images, retries=10):
 
 def sample_real_image(datasets, index):
     cumulative_sizes = np.cumsum([len(ds) for ds in datasets])
-    source_index = np.searchsorted(cumulative_sizes, index % (cumulative_sizes[-1]))
+    source_index = np.searchsorted(cumulative_sizes - 1, index % (cumulative_sizes[-1]))
     source = datasets[source_index]
     valid_index = index - (cumulative_sizes[source_index - 1] if source_index > 0 else 0)
     return source, valid_index

--- a/tests/fixtures/image_transforms.py
+++ b/tests/fixtures/image_transforms.py
@@ -3,7 +3,7 @@ import torchvision.transforms as transforms
 
 from bitmind.constants import TARGET_IMAGE_SIZE
 from bitmind.image_transforms import (
-    CenterCrop,
+    center_crop,
     RandomResizedCropWithParams,
     RandomHorizontalFlipWithParams,
     RandomVerticalFlipWithParams,
@@ -16,7 +16,7 @@ from bitmind.image_transforms import (
 
 
 TRANSFORMS = [
-    CenterCrop,
+    center_crop,
     RandomHorizontalFlipWithParams,
     RandomVerticalFlipWithParams,
     partial(RandomRotationWithParams, degrees=20, interpolation=transforms.InterpolationMode.BILINEAR),


### PR DESCRIPTION
Introducing data augmentation levels to better reward high performing miners.

- Level 0 (25%): No augmentations (base transforms)
- Level 1 (45%): Random transformations
- Level 2 (15%): Random transformations + Medium distortions
- Level 3 (15%): Random transformations + Hard distortions

Distortion-specific parameters (only indices 0, 1 are used):
```
'CS': [0.4, 0.3, 0.2, 0.1, 0.0],  # smaller, worse
'CC': [0.85, 0.725, 0.6, 0.475, 0.35],  # smaller, worse
'BW': [16, 32, 48, 64, 80],  # larger, worse
'GNC': [0.001, 0.002, 0.005, 0.01, 0.05],  # larger, worse
'GB': [7, 9, 13, 17, 21],  # larger, worse
'JPEG': [2, 3, 4, 5, 6]  # larger, worse
```

Medium Distortions (Color saturation, color contrast, JPEG compression)
Parameter probabilities for each distortion: 50% not applied, 50% index 0

```
ApplyDeeperForensicsDistortion('CS', level_min=0, level_max=1),
ApplyDeeperForensicsDistortion('CC', level_min=0, level_max=1),
ApplyDeeperForensicsDistortion('JPEG', level_min=0, level_max=1)
```

Hard Distortions (Color saturation, color contrast, JPEG compression, Gaussian noise color, Gaussian blur)
Parameter probabilities for each distortion: 33% not applied, 33% index 0, 33% index 1

```
ApplyDeeperForensicsDistortion('CS', level_min=0, level_max=2),
ApplyDeeperForensicsDistortion('CC', level_min=0, level_max=2), 
ApplyDeeperForensicsDistortion('JPEG', level_min=0, level_max=2),
ApplyDeeperForensicsDistortion('GNC', level_min=0, level_max=2),
ApplyDeeperForensicsDistortion('GB', level_min=0, level_max=2)
```

Additional minor refactor for image_transforms.py.

