### PR TITLE
Adding two finetuned image models to expand validator challenges

### DIFF
--- a/bitmind/constants.py
+++ b/bitmind/constants.py
@@ -89,6 +89,18 @@ VALIDATOR_MODEL_META = {
             },
             "enable_cpu_offload": False,
             "pipeline": "FluxPipeline"
+        },
+        {
+            "path": "prompthero/openjourney-v4",
+            "use_safetensors": True,
+            "torch_dtype": torch.float16,
+            "pipeline": "StableDiffusionPipeline"
+        },
+        {
+            "path": "cagliostrolab/animagine-xl-3.1",
+            "use_safetensors": True,
+            "torch_dtype": torch.float16,
+            "pipeline": "StableDiffusionXLPipeline"
         }
     ]
 }

--- a/bitmind/synthetic_image_generation/synthetic_image_generator.py
+++ b/bitmind/synthetic_image_generation/synthetic_image_generator.py
@@ -1,6 +1,6 @@
 from transformers import pipeline
 from transformers import set_seed
-from diffusers import StableDiffusionXLPipeline, FluxPipeline
+from diffusers import StableDiffusionXLPipeline, FluxPipeline, StableDiffusionPipeline
 import bittensor as bt
 import numpy as np
 import torch

--- a/bitmind/synthetic_image_generation/synthetic_image_generator.py
+++ b/bitmind/synthetic_image_generation/synthetic_image_generator.py
@@ -260,7 +260,7 @@ class SyntheticImageGenerator:
             tuple: A tuple containing the tokenizer and its maximum token length.
         """
         # Check if a second tokenizer is available in the diffuser
-        if self.diffuser.tokenizer_2:
+        if hasattr(self.diffuser, 'tokenizer_2'):
             if self.diffuser.tokenizer.model_max_length > self.diffuser.tokenizer_2.model_max_length:
                 return self.diffuser.tokenizer_2, self.diffuser.tokenizer_2.model_max_length
         return self.diffuser.tokenizer, self.diffuser.tokenizer.model_max_length


### PR DESCRIPTION
These changes introduce two popular open source image models for validator challenges, as part of our continuous effort to meaningfully expand the distribution of synthetic images that miners classify. Our goal is to encourage better miner generalizability to images produced by different deepfake methods.

**For validators:** No new dependencies/install requirements were added.

**For miners:** We foresee a difficulty increase in subnet challenges as miners adapt to the new models' image distributions.

The two models are:

- [prompthero/openjourney-v4](https://huggingface.co/prompthero/openjourney-v4), a popular StableDiffusion model finetuned on +124k Midjourney v4 images, by [PromptHero](https://prompthero.com/?utm_source=huggingface&utm_medium=referral) (158,394 downloads last month as of writing)
- [cagliostrolab/animagine-xl-3.1](https://huggingface.co/cagliostrolab/animagine-xl-3.1), a popular StableDiffusionXL model finetuned on anime images, by [Cagliostro Research Lab](https://huggingface.co/cagliostrolab) in collaboration with [SeaArt.ai](https://www.seaart.ai/) (411,846 downloads last month as of writing)

These were selected by

1. Manually reviewing state-of-the-art models (tech review blogs, AI news, Hugging Face models) and open source models finetuned on proprietary image generators (e.g. Midjourney) and/or popular generated image genres in-the-wild (e.g. anime)
2. Applying our [subnet API benchmarking](https://www.notion.so/bitmindlabs/Subnet-API-Benchmark-13eaf854028380c1bebdcee58508995f) procedure to synthetic mirrors generated by candidate models.
   - Notably, our subnet scored worse on openjourney-v4 and animagine-xl-3.1 (68.76% and 83.8% accuracy) than any of our existing validator challenge models, indicating that miners have yet to optimally generalize to those model output distributions (supporting the addition of these models).
   - We sourced the real images for mirroring through a scraping method outlined in the technical blog post (link above).
   - API benchmarking for new model selection was conducted end-to-end within 24-HR spans to increase the likelihood that accuracy measures reflected a stable subnet state (as opposed to accuracy variations caused by significant miner changes on mainnet).