### PR TITLE
Updated transformers version to fix tokenizer initialization error

### DIFF
--- a/requirements-validator.txt
+++ b/requirements-validator.txt
@@ -1,5 +1,5 @@
 httpx==0.27.0
 diffusers==0.30.0
-transformers==4.44.0
+transformers==4.46.3
 sentencepiece==0.2.0
 bitsandbytes==0.43.3


### PR DESCRIPTION
Fixed transformers library version deprecation, causing errors upon the initialization of tokenizers for our image annotation models.