### PR TITLE
Score Adjustment

### DIFF
--- a/bitmind/__init__.py
+++ b/bitmind/__init__.py
@@ -18,7 +18,7 @@
 # DEALINGS IN THE SOFTWARE.
 
 
-__version__ = "2.1.1"
+__version__ = "2.1.2"
 version_split = __version__.split(".")
 __spec_version__ = (
     (1000 * int(version_split[0]))

--- a/bitmind/base/validator.py
+++ b/bitmind/base/validator.py
@@ -370,7 +370,7 @@ class BaseValidatorNeuron(BaseNeuron):
 
         # Compute forward pass rewards, assumes uids are mutually exclusive.
         # shape: [ metagraph.n ]
-        scattered_rewards: np.ndarray = self.scores.copy()
+        scattered_rewards: np.ndarray = np.full_like(self.scores, 0.5)
         scattered_rewards[uids_array] = rewards
         bt.logging.debug(f"Scattered rewards: {rewards}")
 

--- a/bitmind/utils/config.py
+++ b/bitmind/utils/config.py
@@ -291,7 +291,7 @@ def add_validator_args(cls, parser):
         "--neuron.moving_average_alpha",
         type=float,
         help="Moving average alpha parameter, how much to add of the new observation.",
-        default=0.02,
+        default=0.05,
     )
 
     parser.add_argument(


### PR DESCRIPTION
Increasing EMA alpha slightly & reintroducing a weaker decay to score after observing miners entrenched in their incentive positions.
- Alpha: 0.02 -> 0.05
- Decay: Miners decay towards 0.5 rather than 0 as prior to 2.1.0