### PR TITLE
[Hotfix] Default previous score value fix

### DIFF
--- a/bitmind/base/validator.py
+++ b/bitmind/base/validator.py
@@ -371,6 +371,12 @@ class BaseValidatorNeuron(BaseNeuron):
         # Compute forward pass rewards, assumes uids are mutually exclusive.
         # shape: [ metagraph.n ]
         scattered_rewards: np.ndarray = np.full_like(self.scores, 0.5)
+        vali_uids = [
+            uid for uid in range(len(scattered_rewards)) if
+            self.metagraph.validator_permit[uid] and 
+            self.metagraph.S[uid] > self.config.neuron.vpermit_tao_limit
+        ]
+        scattered_rewards[vali_uids] = 0.
         scattered_rewards[uids_array] = rewards
         bt.logging.debug(f"Scattered rewards: {rewards}")
 


### PR DESCRIPTION
Fix: previous score value set to 0 in EMA for validators