### PR TITLE
[Testnet] Multiclass Rewards

### DIFF
--- a/bitmind/__init__.py
+++ b/bitmind/__init__.py
@@ -18,7 +18,7 @@
 # DEALINGS IN THE SOFTWARE.
 
 
-__version__ = "2.1.5"
+__version__ = "2.2.0"
 version_split = __version__.split(".")
 __spec_version__ = (
     (1000 * int(version_split[0]))

--- a/bitmind/__init__.py
+++ b/bitmind/__init__.py
@@ -18,7 +18,7 @@
 # DEALINGS IN THE SOFTWARE.
 
 
-__version__ = "2.1.4"
+__version__ = "2.1.5"
 version_split = __version__.split(".")
 __spec_version__ = (
     (1000 * int(version_split[0]))

--- a/bitmind/base/validator.py
+++ b/bitmind/base/validator.py
@@ -406,14 +406,17 @@ class BaseValidatorNeuron(BaseNeuron):
                 new_labels = deque(maxlen=tracker.store_last_n_predictions)
 
                 for pred, label in zip(tracker.prediction_history[uid], tracker.label_history[uid]):
-                    if pred != -1:
-                        # convert old binary prediction to probability vector [p_real, p_synthetic, p_semi]
-                        new_pred = np.array([1 - pred, pred, 0.0])
-                        new_predictions.append(new_pred)
-                        new_labels.append(label)
+                    new_labels.append(label)
+                    if isinstance(pred, float):
+                        if pred != -1:
+                            # convert old binary prediction to probability vector [p_real, p_synthetic, p_semi]
+                            new_predictions.append(np.array([1 - pred, pred, 0.0]))
+                        else:
+                            new_predictions.append(np.array([-1., -1., -1.]))
+                    elif isinstance(pred, np.ndarray):
+                        new_predictions.append(pred)
                     else:
-                        new_predictions.append(-1)
-                        new_labels.append(label)
+                        raise ValueError(f"Invalid prediction type encountered while loading history: {pred}")
 
                 new_tracker.prediction_history[uid] = new_predictions
                 new_tracker.label_history[uid] = new_labels

--- a/bitmind/base/validator.py
+++ b/bitmind/base/validator.py
@@ -19,6 +19,7 @@
 
 from traceback import print_exception
 from typing import List, Union
+from collections import deque
 import bittensor as bt
 import numpy as np
 import threading
@@ -239,7 +240,8 @@ class BaseValidatorNeuron(BaseNeuron):
 
     def set_weights(self):
         """
-        Sets the validator weights to the metagraph hotkeys based on the scores it has received from the miners. The weights determine the trust and incentive level the validator assigns to miner nodes on the network.
+        Sets the validator weights to the metagraph hotkeys based on the scores it has received from the miners. 
+        The weights determine the trust and incentive level the validator assigns to miner nodes on the network.
         """
 
         # Check if self.scores contains any NaN values and log a warning if it does.
@@ -393,16 +395,45 @@ class BaseValidatorNeuron(BaseNeuron):
         joblib.dump(self.performance_trackers['video'], self.video_history_cache_path)
 
     def load_miner_history(self):
+        def convert_v1_to_v2(tracker):
+            """Convert a v1 tracker to v2 format"""
+            new_tracker = MinerPerformanceTracker(tracker.store_last_n_predictions)
+
+            # copy hotkeys, transform predictions from float to vector
+            new_tracker.miner_hotkeys = tracker.miner_hotkeys.copy()
+            for uid in tracker.prediction_history:
+                new_predictions = deque(maxlen=tracker.store_last_n_predictions)
+                new_labels = deque(maxlen=tracker.store_last_n_predictions)
+
+                for pred, label in zip(tracker.prediction_history[uid], tracker.label_history[uid]):
+                    if pred != -1:
+                        # convert old binary prediction to probability vector [p_real, p_synthetic, p_semi]
+                        new_pred = np.array([1 - pred, pred, 0.0])
+                        new_predictions.append(new_pred)
+                        new_labels.append(label)
+                    else:
+                        new_predictions.append(-1)
+                        new_labels.append(label)
+
+                new_tracker.prediction_history[uid] = new_predictions
+                new_tracker.label_history[uid] = new_labels
+            return new_tracker
+
         def load(path):
             if os.path.exists(path):
                 bt.logging.info(f"Loading miner performance history from {path}")
                 try:
                     tracker = joblib.load(path)
+                    if not hasattr(tracker, 'version'):
+                        bt.logging.info(f"Converting performance tracker from v1 to v2 format")
+                        tracker = convert_v1_to_v2(tracker)
+
                     num_miners_history = len([
                         uid for uid in tracker.prediction_history
-                        if len([p for p in tracker.prediction_history[uid] if p != -1]) > 0
+                        if len([p for p in tracker.prediction_history[uid] if not np.array_equal(p, -1)]) > 0
                     ])
                     bt.logging.info(f"Loaded history for {num_miners_history} miners")
+
                 except Exception as e:
                     bt.logging.error(f'Error loading miner performance tracker: {e}')
                     tracker = MinerPerformanceTracker()
@@ -411,14 +442,7 @@ class BaseValidatorNeuron(BaseNeuron):
                 tracker = MinerPerformanceTracker()
             return tracker
 
-        try:
-            self.performance_trackers['image'] = load(self.image_history_cache_path)
-        except Exception as e:
-            # just for 2.0.0 upgrade for miner performance to carry over
-            v1_history_cache_path = os.path.join(
-                self.config.neuron.full_path, "miner_performance_tracker.pkl")
-            self.performance_trackers['image'] = load(v1_history_cache_path)
-
+        self.performance_trackers['image'] = load(self.image_history_cache_path)
         self.performance_trackers['video'] = load(self.video_history_cache_path)
 
     def save_state(self):

--- a/bitmind/protocol.py
+++ b/bitmind/protocol.py
@@ -17,7 +17,7 @@
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 # DEALINGS IN THE SOFTWARE.
 
-from typing import List
+from typing import List, Union
 from pydantic import BaseModel, Field
 from torchvision import transforms
 from io import BytesIO
@@ -100,11 +100,10 @@ class ImageSynapse(bt.Synapse):
         frozen=False
     )
 
-    # Optional request output, filled by receiving axon.
-    prediction: float = pydantic.Field(
+    prediction: Union[float, List[float]] = pydantic.Field(
         title="Prediction",
-        description="Probability that the image is AI generated/modified",
-        default=-1.,
+        description="Probability vector for [real, synthetic, semi-synthetic] classes.",
+        default=[-1., -1., -1],
         frozen=False
     )
 
@@ -153,10 +152,10 @@ class VideoSynapse(bt.Synapse):
     )
 
     # Optional request output, filled by receiving axon.
-    prediction: float = pydantic.Field(
+    prediction: Union[float, List[float]] = pydantic.Field(
         title="Prediction",
-        description="Probability that the image is AI generated/modified",
-        default=-1.,
+        description="Probability vector for [real, synthetic, semi-synthetic] classes.",
+        default=[-1., -1., -1],
         frozen=False
     )
 
@@ -214,9 +213,7 @@ def decode_video_synapse(synapse: VideoSynapse) -> List[torch.Tensor]:
             # Extract the JPEG data
             jpeg_data = combined_bytes[start_pos:current_pos]
             try:
-                # Convert to PIL Image
                 img = Image.open(BytesIO(jpeg_data))
-                # Convert to numpy array
                 frames.append(img)
             except Exception as e:
                 print(f"Error processing frame: {e}")

--- a/bitmind/validator/forward.py
+++ b/bitmind/validator/forward.py
@@ -168,6 +168,9 @@ async def forward(self):
     bt.logging.success(f"{CHALLENGE_TYPE[label]} {modality} challenge complete!")
     bt.logging.info({k: v for k, v in challenge_metadata.items() if k not in ('miner_uids', 'miner_hotkeys')})
 
+    # handle previous protocol where prediction was a float
+    responses = [[1-r, r, 0.] if isinstance(r, float) else r for r in responses]
+
     bt.logging.info(f"Scoring responses")
     rewards, metrics = get_rewards(
         label=label,

--- a/bitmind/validator/forward.py
+++ b/bitmind/validator/forward.py
@@ -169,7 +169,10 @@ async def forward(self):
     bt.logging.info({k: v for k, v in challenge_metadata.items() if k not in ('miner_uids', 'miner_hotkeys')})
 
     # handle previous protocol where prediction was a float
-    responses = [[1-r, r, 0.] if isinstance(r, float) else r for r in responses]
+    responses = [
+        np.array([1-r, r, 0.]) if isinstance(r, float)
+        else np.array(r) for r in responses
+    ]
 
     bt.logging.info(f"Scoring responses")
     rewards, metrics = get_rewards(

--- a/bitmind/validator/miner_performance_tracker.py
+++ b/bitmind/validator/miner_performance_tracker.py
@@ -4,11 +4,13 @@ from collections import deque
 import bittensor as bt
 import numpy as np
 
+
 class MinerPerformanceTracker:
     """
     Tracks all recent miner performance to facilitate reward computation.
     """
     VERSION = 2
+
     def __init__(self, store_last_n_predictions: int = 100):
         self.prediction_history: Dict[int, deque] = {}
         self.label_history: Dict[int, deque] = {}
@@ -33,7 +35,7 @@ class MinerPerformanceTracker:
         """
         if uid not in self.prediction_history or self.miner_hotkeys.get(uid) != miner_hotkey:
             self.reset_miner_history(uid, miner_hotkey)
-        self.prediction_history[uid].append(prediction)   # store full probability vector
+        self.prediction_history[uid].append(np.array(prediction))   # store full probability vector
         self.label_history[uid].append(label)
 
     def get_metrics(self, uid: int, window: int = None):

--- a/bitmind/validator/miner_performance_tracker.py
+++ b/bitmind/validator/miner_performance_tracker.py
@@ -1,4 +1,4 @@
-from sklearn.metrics import accuracy_score, precision_score, recall_score, f1_score, matthews_corrcoef, roc_auc_score
+from sklearn.metrics import f1_score
 from typing import Dict, List
 from collections import deque
 import bittensor as bt
@@ -23,29 +23,23 @@ class MinerPerformanceTracker:
         self.label_history[uid] = deque(maxlen=self.store_last_n_predictions)
         self.miner_hotkeys[uid] = miner_hotkey
 
-    def update(self, uid: int, prediction: int, label: int, miner_hotkey: str):
+    def update(self, uid: int, prediction: np.ndarray, label: int, miner_hotkey: str):
         """
         Update the miner prediction history
+
+        Args:
+        - prediction: numpy array of shape (3,) containing probabilities for [real, synthetic, semi-synthetic]
+        - label: integer label (0 for real, 1 for synthetic, 2 for semi-synthetic)
         """
-        # Reset histories if miner is new or miner address has changed
         if uid not in self.prediction_history or self.miner_hotkeys.get(uid) != miner_hotkey:
             self.reset_miner_history(uid, miner_hotkey)
 
-        # Update histories
-        self.prediction_history[uid].append(prediction)
+        self.prediction_history[uid].append(prediction)   # store full probability vector
         self.label_history[uid].append(label)
 
     def get_metrics(self, uid: int, window: int = None):
         """
         Get the performance metrics for a miner based on their last n predictions
-
-        Args:
-        - uid (int): The unique identifier of the miner
-        - window (int, optional): The number of recent predictions to consider. 
-        - If None, all stored predictions are used.
-
-        Returns:
-        - dict: A dictionary containing various performance metrics
         """
         if uid not in self.prediction_history:
             return self._empty_metrics()
@@ -53,62 +47,49 @@ class MinerPerformanceTracker:
         recent_preds = list(self.prediction_history[uid])
         recent_labels = list(self.label_history[uid])
 
-        # If window is larger than available data, use all available data
         if window is not None:
             window = min(window, len(recent_preds))
             recent_preds = recent_preds[-window:]
             recent_labels = recent_labels[-window:]
 
-        keep_idx = [i for i, p in enumerate(recent_preds) if p != -1]
-        pred_probs = np.array([recent_preds[i] for i in keep_idx])
-        predictions = np.round(pred_probs)
-        labels = np.array([recent_labels[i] for i in keep_idx])
+        pred_probs = np.array([p for p in recent_preds if not np.array_equal(p, -1)])
+        labels = np.array([l for i, l in enumerate(recent_labels) if not np.array_equal(recent_preds[i], -1)])
 
-        if len(labels) == 0 or len(predictions) == 0:
+        if len(labels) == 0 or len(pred_probs) == 0:
             return self._empty_metrics()
 
         try:
-            accuracy = accuracy_score(labels, predictions)
-            precision = precision_score(labels, predictions, zero_division=0)
-            recall = recall_score(labels, predictions, zero_division=0)
-            f1 = f1_score(labels, predictions, zero_division=0)
-            mcc = max(0, matthews_corrcoef(labels, predictions)) if len(np.unique(labels)) > 1 else 0.0
-            auc = roc_auc_score(labels, pred_probs) if len(np.unique(labels)) > 1 else 0.0
+            predictions = np.argmax(pred_probs, axis=1)
+
+            # multiclass F1 (real vs synthetic vs semi-synthetic)
+            multi_class_f1 = f1_score(labels, predictions, average='weighted')
+
+            # binary f-1 (real vs any synthetic)
+            binary_labels = (labels > 0).astype(int)
+            binary_preds = (predictions > 0).astype(int)
+            binary_f1 = f1_score(binary_labels, binary_preds)
+
+            return {
+                'multi_class_f1': multi_class_f1,
+                'binary_f1': binary_f1
+            }
+
         except Exception as e:
             bt.logging.warning(f'Error in reward computation: {e}')
             return self._empty_metrics()
-
-        return {
-            'accuracy': accuracy,
-            'precision': precision,
-            'recall': recall,
-            'f1_score': f1,
-            'mcc': mcc,
-            'auc': auc
-        }
 
     def _empty_metrics(self):
         """
         Return a dictionary of empty metrics
         """
         return {
-            'accuracy': 0,
-            'precision': 0,
-            'recall': 0,
-            'f1_score': 0,
-            'mcc': 0,
-            'auc': 0
+            'multi_class_f1': 0,
+            'binary_f1': 0
         }
 
     def get_prediction_count(self, uid: int) -> int:
         """
         Get the number of predictions made by a specific miner.
-
-        Args:
-        - uid (int): The unique identifier of the miner
-
-        Returns:
-        - int: The number of predictions made by the miner
         """
         if uid not in self.prediction_history:
             return 0

--- a/bitmind/validator/miner_performance_tracker.py
+++ b/bitmind/validator/miner_performance_tracker.py
@@ -9,11 +9,14 @@ class MinerPerformanceTracker:
     """
     Tracks all recent miner performance to facilitate reward computation.
     """
+    VERSION = 2
+
     def __init__(self, store_last_n_predictions: int = 100):
         self.prediction_history: Dict[int, deque] = {}
         self.label_history: Dict[int, deque] = {}
         self.miner_hotkeys: Dict[int, str] = {}
         self.store_last_n_predictions = store_last_n_predictions
+        self.version = self.VERSION
 
     def reset_miner_history(self, uid: int, miner_hotkey: str):
         """

--- a/bitmind/validator/reward.py
+++ b/bitmind/validator/reward.py
@@ -37,6 +37,10 @@ def compute_penalty_multiplier(y_pred: np.ndarray) -> float:
     return 1.0 if (sum_check and range_check) else 0.0
 
 
+def transform_rational(mcc, pole=1.01):
+    return 1 / (pole - np.array(mcc))
+
+
 def get_rewards(
     label: int,
     responses: List[np.ndarray],
@@ -81,7 +85,8 @@ def get_rewards(
                     tracker.update(uid, pred_probs, label, miner_hotkey)
 
                 metrics = tracker.get_metrics(uid, window=100)
-                reward = (0.7 * metrics['binary_f1'] + 0.3 * metrics['multi_class_f1'])
+                reward = (0.9 * metrics['binary_mcc'] + 0.1 * metrics['multi_class_mcc'])
+                reward = transform_rational(reward)
                 reward *= compute_penalty_multiplier(pred_probs)
                 
                 miner_modality_rewards[modality] = reward

--- a/bitmind/validator/reward.py
+++ b/bitmind/validator/reward.py
@@ -17,29 +17,29 @@
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 # DEALINGS IN THE SOFTWARE.
 
-
 from typing import List, Dict, Tuple, Any
 import bittensor as bt
 import numpy as np
 
 
-def compute_penalty(y_pred: float) -> float:
+def compute_penalty_multiplier(y_pred: np.ndarray) -> float:
     """
     Compute penalty for predictions outside valid range.
 
     Args:
-        y_pred (float): Predicted value
+        y_pred (np.ndarray): Predicted probabilities for each class, shape (3,)
 
     Returns:
         float: 0.0 if prediction is invalid, 1.0 if valid
     """
-    bad = (y_pred < 0.0) or (y_pred > 1.0)
-    return 0.0 if bad else 1.0
+    sum_check = np.abs(np.sum(y_pred) - 1.0) < 1e-6
+    range_check = np.all((y_pred >= 0.0) & (y_pred <= 1.0))
+    return 1.0 if (sum_check and range_check) else 0.0
 
 
 def get_rewards(
-    label: float,
-    responses: List[float],
+    label: int,
+    responses: List[np.ndarray],
     uids: List[int],
     axons: List[bt.axon],
     challenge_modality: str,
@@ -49,8 +49,8 @@ def get_rewards(
     Calculate rewards for miner responses based on performance metrics.
 
     Args:
-        label: The true label (1.0 for fake, 0.0 for real)
-        responses: List of responses from the miners
+        label: The true label (0 for real, 1 for synthetic, 2 for semi-synthetic)
+        responses: List of probability vectors from miners, each shape (3,)
         uids: List of miner UIDs
         axons: List of miner axons
         challenge_modality: Type of challenge ('video' or 'image')
@@ -64,7 +64,7 @@ def get_rewards(
     miner_rewards = []
     miner_metrics = []
 
-    for axon, uid, pred_prob in zip(axons, uids, responses):
+    for axon, uid, pred_probs in zip(axons, uids, responses):
         miner_modality_rewards = {}
         miner_modality_metrics = {}
 
@@ -73,36 +73,29 @@ def get_rewards(
             try:
                 miner_hotkey = axon.hotkey
 
-                tracked_hotkeys = tracker.miner_hotkeys
-                if uid in tracked_hotkeys and tracked_hotkeys[uid] != miner_hotkey:
-                    bt.logging.info(
-                        f"Miner hotkey changed for UID {uid}. Resetting performance metrics."
-                    )
+                if uid in tracker.miner_hotkeys and tracker.miner_hotkeys[uid] != miner_hotkey:
+                    bt.logging.info(f"Miner hotkey changed for UID {uid}. Resetting performance metrics.")
                     tracker.reset_miner_history(uid, miner_hotkey)
 
                 if modality == challenge_modality:
-                    performance_trackers[modality].update(
-                        uid, pred_prob, label, miner_hotkey
-                    )
+                    tracker.update(uid, pred_probs, label, miner_hotkey)
 
-                metrics_100 = tracker.get_metrics(uid, window=100)
-                metrics_10 = tracker.get_metrics(uid, window=10)
-                reward = 0.5 * metrics_100['mcc'] + 0.5 * metrics_10['accuracy']
-                reward *= compute_penalty(pred_prob)
+                metrics = tracker.get_metrics(uid, window=100)
+                reward = (0.7 * metrics['binary_f1'] + 0.3 * metrics['multi_class_f1'])
+                reward *= compute_penalty_multiplier(pred_probs)
+                
                 miner_modality_rewards[modality] = reward
-                miner_modality_metrics[modality] = metrics_100
+                miner_modality_metrics[modality] = metrics
 
             except Exception as e:
-                bt.logging.error(
-                    f"Couldn't calculate reward for miner {uid}, "
-                    f"prediction: {pred_prob}, label: {label}"
-                )
+                bt.logging.error(f"Couldn't calculate reward for miner {uid}, prediction: {pred_probs}, label: {label}")
                 bt.logging.exception(e)
                 miner_rewards.append(0.0)
+                continue
 
         total_reward = (
-            0.4 * miner_modality_rewards['video'] +
-            0.6 * miner_modality_rewards['image']
+            0.4 * miner_modality_rewards.get('video', 0.0) +
+            0.6 * miner_modality_rewards.get('image', 0.0)
         )
         miner_rewards.append(total_reward)
         miner_metrics.append(miner_modality_metrics)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 # Core ML frameworks
-bittensor==8.5.1
+bittensor==9.0.0
 torch==2.5.1
 torchvision==0.20.1
 torchaudio==2.5.1


### PR DESCRIPTION
*Note: Miners will have at least a week from when this release is publicly announced to prepare*

Introducing mutliclass protocols and rewards.

New reward function takes into account differentiation between synthetic and semi-synthetic data, but places a higher weight on binary (real vs. any type of synthetic) F-1. 

- `ImageSynapse` and `VideoSynapse` `prediction` fields now contain probability vectors for `[p_real, p_synthetic, p_semisynthetic]`
- `MinerPerformanceTracker` updated to track probability vectors, and compute both weighted multiclass F1 and binary F1
- `get_rewards` and `compute_penalty_multiplier` updated to handle probability vectors. 

### Backwards Compatibility
- `prediction` dtype set to `Union[float, List[float]]` for backwards compatibility. 
- `Validator.forward()` will transform float predictions `p` to `[1-p, p, 0.]` to allow miners making binary classifications to be rewarded based on their binary accuracy
- When the Validator base class loads the pickled `MinerPerformanceTracker` object, it will check if it's from the previous version and transform historical float predictions to probability vectors (as in `forward()`)