### PR TITLE
fix: Update model configurations for inpainting and scheduler loading

### DIFF
--- a/bitmind/synthetic_data_generation/synthetic_data_generator.py
+++ b/bitmind/synthetic_data_generation/synthetic_data_generator.py
@@ -427,15 +427,23 @@ class SyntheticDataGenerator:
                     model_config['lora_model_id'], 
                     **lora_loading_args
                 )
-
+                
             # Load scheduler if specified
             if 'scheduler' in model_config:
-                sched_cls = model_config['scheduler']['cls']
-                sched_args = model_config['scheduler'].get('from_config_args', {})
-                self.model.scheduler = sched_cls.from_config(
-                    self.model.scheduler.config,
-                    **sched_args
-                )
+                scheduler_config = model_config['scheduler']
+                if 'cls' in scheduler_config:
+                    sched_cls = scheduler_config['cls']
+                    # Only pass args if they exist in config
+                    if 'from_config_args' in scheduler_config:
+                        self.model.scheduler = sched_cls.from_config(
+                            self.model.scheduler.config,
+                            **scheduler_config['from_config_args']
+                        )
+                    else:
+                        # Use default configuration
+                        self.model.scheduler = sched_cls.from_config(
+                            self.model.scheduler.config
+                        )
 
             enable_model_optimizations(
                 model=self.model,

--- a/bitmind/validator/config.py
+++ b/bitmind/validator/config.py
@@ -307,6 +307,11 @@ I2I_MODELS: Dict[str, Dict[str, Any]] = {
     },
     "stable-diffusion-v1-5/stable-diffusion-inpainting": {
         "pipeline_cls": StableDiffusionInpaintPipeline,
+        "from_pretrained_args": {
+            "torch_dtype": torch.float16,
+            "variant": "fp16",
+            "use_safetensors": True
+        },
         "generate_args": {
             "num_inference_steps": {"min": 40, "max": 60},
         }


### PR DESCRIPTION
- Add support for basic scheduler configs without args
- Add from_pretrained_args for stable-diffusion-inpainting with fp16 support