### PR TITLE
W&B Logging + Augmentation Fix

### DIFF
--- a/bitmind/utils/image_transforms.py
+++ b/bitmind/utils/image_transforms.py
@@ -11,10 +11,10 @@ from bitmind.validator.config import TARGET_IMAGE_SIZE
 
 
 def center_crop():
-    def fn(img):
+    def crop(img):
         m = min(img.size)
         return transforms.CenterCrop(m)(img)
-    return fn
+    return crop
 
 
 class RandomResizedCropWithParams(transforms.RandomResizedCrop):
@@ -275,6 +275,7 @@ class ApplyDeeperForensicsDistortion:
         self.distortion_type = distortion_type
         self.level_min = level_min
         self.level_max = level_max
+        self.params = {}
 
     def __call__(self, img, level=None):
         if level is None:
@@ -297,6 +298,7 @@ class ApplyDeeperForensicsDistortion:
             img = img.permute(1, 2, 0).cpu().numpy()
             img = (img * 255).astype(np.uint8)
 
+        self.params = {'level': self.level}
         img = self.distortion_func(img, self.distortion_param)
 
         if isinstance(img, np.ndarray):

--- a/bitmind/validator/cache/extract.py
+++ b/bitmind/validator/cache/extract.py
@@ -71,6 +71,7 @@ q
 
                     video_info = zip_file.getinfo(video)
                     metadata = {
+                        'dataset': str(Path(zip_path).parent.name),
                         'source_zip': str(zip_path),
                         'path_in_zip': video,
                         'extraction_date': datetime.now().isoformat(),
@@ -164,6 +165,7 @@ def extract_images_from_parquet(
             img.save(img_path)
 
             metadata = {
+                'dataset': str(Path(parquet_path).parent.name),
                 'source_parquet': str(parquet_path),
                 'original_index': str(idx),
                 'image_format': image_format,

--- a/bitmind/validator/cache/image_cache.py
+++ b/bitmind/validator/cache/image_cache.py
@@ -127,7 +127,7 @@ class ImageCache(BaseCache):
                 return {
                     'image': image,
                     'path': str(image_path),
-                    'dataset': metadata.get('dataset', None),
+                    'dataset': metadata.get('dataset', str(Path(image_path).parent.name),),
                     'index': metadata.get('index', None),
                     'mask_center': metadata.get('mask_center', None)
                 }

--- a/bitmind/validator/cache/video_cache.py
+++ b/bitmind/validator/cache/video_cache.py
@@ -215,7 +215,7 @@ class VideoCache(BaseCache):
             'fps': frame_rate,
             'num_frames': num_frames,
             'path': str(video_path),
-            'dataset': str(Path(video_path).name.split('_')[0]),
+            'dataset': str(Path(video_path).parent.name),
             'total_duration': duration,
             'sampled_length': sample_duration
         }

--- a/bitmind/validator/challenge.py
+++ b/bitmind/validator/challenge.py
@@ -152,7 +152,13 @@ class Challenge:
             if self.modality == 'video':
                 def create_wandb_video(video_frames, fps):
                     frames = [np.array(img) for img in video_frames]
-                    frames_arr = np.stack(frames, axis=0).transpose(0, 3, 1, 2)
+                    frames_arr = np.stack(frames, axis=0)
+                    if frames_arr.min() >= 0 and frames_arr.max() <= 1:
+                        frames_arr = (frames_arr * 255).astype(np.uint8)
+
+                    if frames_arr.shape[1] != 3:
+                        frames_arr = frames_arr.transpose(0, 3, 1, 2)
+
                     return wandb.Video(frames_arr, format="mp4", fps=fps)
 
                 if 'video_A' in sample:


### PR DESCRIPTION
- Fixing logging of augmented videos to w&b
  - `create_wandb_video` had assumed lists of PILs, augmented video is a tensor when it gets passed
  - Now `create_wandb_video` checks shape before transposing to [B, C, F, H, W]
- FIxing application of  DeeperForensics distortions, previously not applied with uniform parameters across frames
  - `ComposeWithParams` was looking at the `ApplyDeeperForensicsDistortion` for persisted parameters rather than its encapsulated distortion function -- added params['level'] as a fix.  
  
Will soon replace this pipeline with one that operates natively on tensors, avoiding the need to loop over frames and persist/reapply augmentation params