### PR TITLE
Add metadata to testnet requests

### DIFF
--- a/bitmind/epistula.py
+++ b/bitmind/epistula.py
@@ -101,6 +101,7 @@ async def query_miner(
     total_timeout: float,
     connect_timeout: Optional[float] = None,
     sock_connect_timeout: Optional[float] = None,
+    testnet_metadata: dict = None,
 ) -> Dict[str, Any]:
     """
     Query a miner with media data.
@@ -130,16 +131,22 @@ async def query_miner(
 
     try:
 
-        headers = generate_header(hotkey, media, axon_info.hotkey)
         url = f"http://{axon_info.ip}:{axon_info.port}/detect_{modality}"
+        headers = generate_header(hotkey, media, axon_info.hotkey)
+
+        headers = {
+            "Content-Type": content_type,
+            "X-Media-Type": modality,
+            **headers,
+        }
+
+        if testnet_metadata:
+            testnet_headers = {f"X-Testnet-{k}": str(v) for k, v in testnet_metadata.items()}
+            headers.update(testnet_headers)
 
         async with session.post(
             url,
-            headers={
-                "Content-Type": content_type,
-                "X-Media-Type": modality,
-                **headers,
-            },
+            headers=headers,
             data=media,
             timeout=aiohttp.ClientTimeout(
                 total=total_timeout,

--- a/neurons/validator.py
+++ b/neurons/validator.py
@@ -87,7 +87,7 @@ class Validator(BaseNeuron):
                 self.send_challenge_to_miners_on_interval,
                 self.update_compressed_cache_on_interval,
                 self.update_media_cache_on_interval,
-                self.start_new_wanbd_run_on_interval
+                self.start_new_wanbd_run_on_interval,
             ]
         )
 
@@ -218,6 +218,11 @@ class Validator(BaseNeuron):
                         self.config.neuron.miner_total_timeout,
                         self.config.neuron.miner_connect_timeout,
                         self.config.neuron.miner_sock_connect_timeout,
+                        testnet_metadata=(
+                            media_sample["metadata"]
+                            if self.config.netuid != MAINNET_UID
+                            else {}
+                        ),
                     )
                 )
             if len(challenge_tasks) != 0:


### PR DESCRIPTION
Adding media metadata to testnet requests to help miners track performance more conveniently