### PR TITLE
[testnet] Miner healthchecks

### DIFF
--- a/bitmind/autoupdater.py
+++ b/bitmind/autoupdater.py
@@ -74,7 +74,15 @@ def autoupdate(branch: str = "main", force=False):
                 new_version = int("".join(new_version.split(".")))
 
                 if new_version == latest_version:
-                    bt.logging.info("Updated successfully. Restarting...")
+                    bt.logging.info("Updated successfully.")
+
+                    bt.logging.info("Restarting generator...")
+                    subprocess.run(["pm2", "reload", "sn34-generator"], check=True)
+
+                    bt.logging.info("Restarting proxy...")
+                    subprocess.run(["pm2", "reload", "sn34-proxy"], check=True)
+
+                    bt.logging.info(f"Restarting validator")
                     os.kill(os.getpid(), signal.SIGINT)
                 else:
                     bt.logging.error("Update failed. Manual update required.")

--- a/bitmind/config.py
+++ b/bitmind/config.py
@@ -380,3 +380,18 @@ def add_proxy_args(parser):
         default=10913,
         help="Port for the proxy server",
     )
+
+    parser.add_argument(
+        "--proxy.sample_size",
+        type=int,
+        default=50,
+        help="Number of miners to query for organics",
+    )
+
+    parser.add_argument(
+        "--miner-healthcheck-interval",
+        type=int,
+        default=3,
+        help="How frequently to check miner health (in blocks)",
+    )
+

--- a/bitmind/config.py
+++ b/bitmind/config.py
@@ -391,7 +391,7 @@ def add_proxy_args(parser):
     parser.add_argument(
         "--miner-healthcheck-interval",
         type=int,
-        default=3,
+        default=10,
         help="How frequently to check miner health (in blocks)",
     )
 

--- a/neurons/miner.py
+++ b/neurons/miner.py
@@ -282,6 +282,10 @@ class Miner(BaseNeuron):
             bt.logging.error(traceback.format_exc())
             return {"status": "error", "message": str(e)}
 
+    async def healthcheck(self):
+        """Check if miner is healthy and ready to process requests"""
+        return {"status": "healthy"}
+
     async def determine_epistula_version_and_verify(self, request: Request):
         version = request.headers.get("Epistula-Version")
         if version == EPISTULA_VERSION:
@@ -369,6 +373,7 @@ class Miner(BaseNeuron):
         app = FastAPI()
         router = APIRouter()
         router.add_api_route("/", ping, methods=["GET"])
+        router.add_api_route("/health", self.healthcheck, methods=["GET"])
 
         router.add_api_route(
             "/detect_image",

--- a/neurons/miner.py
+++ b/neurons/miner.py
@@ -373,7 +373,7 @@ class Miner(BaseNeuron):
         app = FastAPI()
         router = APIRouter()
         router.add_api_route("/", ping, methods=["GET"])
-        router.add_api_route("/health", self.healthcheck, methods=["GET"])
+        router.add_api_route("/healthcheck", self.healthcheck, methods=["GET"])
 
         router.add_api_route(
             "/detect_image",

--- a/neurons/proxy.py
+++ b/neurons/proxy.py
@@ -226,6 +226,13 @@ class ValidatorProxy(BaseNeuron):
             block: Current block number
         """
         log_items = [f"Forward Block: {self.subtensor.block}"]
+
+        healthy_count = len([
+            k for k, v in self.miner_health.items() 
+            if v['status'] == 'healthy'
+        ])
+        log_items.append(f"{healthy_count} healthy miner{'s' if healthy_count > 0 else ''}")
+
         if self.request_times.get("image"):
             avg_image_time = sum(self.request_times["image"]) / len(
                 self.request_times["image"]
@@ -239,7 +246,7 @@ class ValidatorProxy(BaseNeuron):
             log_items.append(f"Avg video request: {avg_video_time:.2f}s")
 
         bt.logging.info(" | ".join(log_items))
-        bt.logging.info({k:v for k, v in self.miner_health.items() if v['status'] == 'healthy'})
+
 
     def setup_app(self):
         app = FastAPI(title="BitMind Proxy Server")

--- a/neurons/proxy.py
+++ b/neurons/proxy.py
@@ -38,6 +38,7 @@ from bitmind.utils import on_block_interval
 from neurons.base import BaseNeuron
 
 AUTH_HEADER = APIKeyHeader(name="Authorization")
+DEFAULT_TIMEOUT = 9
 
 
 class MediaProcessor:
@@ -172,7 +173,7 @@ class ValidatorProxy(BaseNeuron):
                 response = client.post(
                     f"{self.config.proxy.client_url}/get-credentials",
                     json={"postfix": f":{self.external_port}", "uid": self.uid},
-                    timeout=9,
+                    timeout=DEFAULT_TIMEOUT,
                 )
                 creds = response.json()
 
@@ -583,7 +584,7 @@ class ValidatorProxy(BaseNeuron):
         start_time = time.time()
         async with aiohttp.ClientSession(
             timeout=aiohttp.ClientTimeout(
-                total=9,
+                total=DEFAULT_TIMEOUT,
                 connect=3,
                 sock_connect=3,
                 sock_read=5,
@@ -638,7 +639,7 @@ class ValidatorProxy(BaseNeuron):
             ip = axon_info.ip
             port = axon_info.port
             url = f"http://{ip}:{port}/healthcheck"
-            async with session.get(url, timeout=5) as response:
+            async with session.get(url, timeout=DEFAULT_TIMEOUT) as response:
                 if response.status == 200:
                     response_json = await response.json()
                     return response_json.get("status") == "healthy"

--- a/neurons/proxy.py
+++ b/neurons/proxy.py
@@ -152,8 +152,6 @@ class ValidatorProxy(BaseNeuron):
         self.auth_verifier = self._setup_auth()
 
         self.miner_health = {}
-        self.health_check_interval = 300
-        self.healthcheck_task = None
 
         self.session = None
         self.max_connections = 50

--- a/neurons/proxy.py
+++ b/neurons/proxy.py
@@ -555,6 +555,7 @@ class ValidatorProxy(BaseNeuron):
             error = r["error"]
             pred = r["prediction"]
 
+            # blacklist miners who have responded >= 3 times with an invalid response 
             if not isinstance(pred, (list, np.ndarray)) or abs(sum(pred) - 1.0) > 1e-6:
                 self.miner_health[uid]["invalid_responses"] += 1
                 if self.miner_health[uid]["invalid_responses"] >= 3:
@@ -602,6 +603,7 @@ class ValidatorProxy(BaseNeuron):
             unhealthy_count = 0
 
             for uid in get_miner_uids(self.metagraph, self.uid, self.config.vpermit_tao_limit):
+                # re-check blacklisted miners after 360 blocks
                 if self.miner_health.get(uid, {}).get("status") == "blacklisted":
                     if self.miner_health[uid]["last_checked_block"] - block > 360:
                         miner_uids_to_check.append(uid)


### PR DESCRIPTION
Periodically check miner health in proxy. Only query healthy miners.

- `check_miners_health_on_interval` runs in the proxy's block callback loop, and fires once every 10 blocks by default
  - First checks the miner's `healthcheck` endpoint, falls back to making an incorrect GET request to `detect_image` and checking for a 405 response (as not all miners will have updated immediately)
- The above function calls `check_miner_health` for each miner uid (which are fetched by `bitmind/metagraph.py`'s  `get_miner_uids`, to avoid checking validators)
- The proxy's `query_miners` function now calls `get_miner_uids_to_query`, which first checks `self.miner_health` for available healthy uids, or if this fails, selects miner uids at random as a fallback.