### PR TITLE
[testnet] Revised Miner Healthcheck

### DIFF
--- a/bitmind/config.py
+++ b/bitmind/config.py
@@ -389,9 +389,9 @@ def add_proxy_args(parser):
     )
 
     parser.add_argument(
-        "--miner-healthcheck-interval",
+        "--miner-health-sync-interval",
         type=int,
-        default=10,
+        default=2,
         help="How frequently to check miner health (in blocks)",
     )
 

--- a/bitmind/epistula.py
+++ b/bitmind/epistula.py
@@ -119,7 +119,9 @@ async def query_miner(
         sock_connect_timeout: Socket connection timeout
 
     Returns:
-        Dictionary containing the response
+        Dictionary containing the response.
+        prediction field will be None if any error is encountered, including
+        if the response contains a prediction that doesn't sum to ~1.
     """
     response = {
         "uid": uid,
@@ -165,16 +167,27 @@ async def query_miner(
                     return response
 
                 pred = [float(p) for p in data["prediction"]]
-                response["prediction"] = np.array(pred)
+
+                # handle binary predictions, assume [real, fake]
+                if len(pred) == 2:
+                    pred = pred + [0.0]
+
+                pred = np.array(pred)
+
+                # error on predictions that don't sum to ~1 or contain values outside of [0., 1.]
+                if abs(sum(pred) - 1.0) > 1e-6 or np.any((pred < 0.0) | (pred > 1.0)):
+                    raise ValueError
+
+                response["prediction"] = pred
                 return response
 
             except json.JSONDecodeError:
                 response["error"] = "Failed to decode JSON response"
                 return response
 
-            except (TypeError, ValueError):
+            except (TypeError, ValueError) as e:
                 response["error"] = (
-                    f"Invalid prediction value: {data.get('prediction')}"
+                    f"Invalid prediction value {data.get('prediction')}"
                 )
                 return response
 
@@ -191,3 +204,5 @@ async def query_miner(
         response["error"] = f"Unknown error: {str(e)}"
 
     return response
+
+

--- a/bitmind/scoring/miner_history.py
+++ b/bitmind/scoring/miner_history.py
@@ -10,7 +10,8 @@ from bitmind.types import Modality
 
 
 class MinerHistory:
-    """Tracks all recent miner performance to facilitate reward computation."""
+    """Tracks all recent miner performance to facilitate reward computation.
+    Will be replaced with Redis in a future release """
 
     VERSION = 2
 
@@ -18,6 +19,7 @@ class MinerHistory:
         self.predictions: Dict[int, Dict[Modality, deque]] = {}
         self.labels: Dict[int, Dict[Modality, deque]] = {}
         self.miner_hotkeys: Dict[int, str] = {}
+        self.health: Dict[int: int] = {}
         self.store_last_n_predictions = store_last_n_predictions
         self.version = self.VERSION
 
@@ -25,6 +27,7 @@ class MinerHistory:
         self,
         uid: int,
         prediction: np.ndarray,
+        error: str,
         label: int,
         modality: Modality,
         miner_hotkey: str,
@@ -42,6 +45,7 @@ class MinerHistory:
 
         self.predictions[uid][modality].append(np.array(prediction))
         self.labels[uid][modality].append(label)
+        self.health[uid] = 1 if not error else 0
 
     def _reset_predictions(self, uid: int):
         self.predictions[uid] = {
@@ -56,7 +60,9 @@ class MinerHistory:
         }
 
     def reset_miner_history(self, uid: int, miner_hotkey: str):
-        """Reset the history for a miner."""
+        """
+        Reset the history for a miner. 
+        """
         self._reset_predictions(uid)
         self._reset_labels(uid)
         self.miner_hotkeys[uid] = miner_hotkey
@@ -79,6 +85,7 @@ class MinerHistory:
             "miner_hotkeys": self.miner_hotkeys,
             "predictions": self.predictions,
             "labels": self.labels,
+            "health": self.health
         }
         joblib.dump(state, path)
 
@@ -100,6 +107,8 @@ class MinerHistory:
             self.miner_hotkeys = state["miner_hotkeys"]
             self.predictions = state["predictions"]
             self.labels = state["labels"]
+            self.health = state["health"]
+
             bt.logging.debug(
                 f"Successfully loaded history for {len(self.miner_hotkeys)} miners"
             )

--- a/bitmind/scoring/miner_history.py
+++ b/bitmind/scoring/miner_history.py
@@ -77,6 +77,12 @@ class MinerHistory:
                 counts[modality] = len(self.predictions[uid][modality])
         return counts
 
+    def get_healthy_miner_uids(self) -> list:
+        return [uid for uid, healthy in self.health.items() if healthy]
+
+    def get_unhealthy_miner_uids(self) -> list:
+        return [uid for uid, healthy in self.health.items() if not healthy]
+
     def save_state(self, save_dir):
         path = os.path.join(save_dir, "history.pkl")
         state = {

--- a/neurons/validator.py
+++ b/neurons/validator.py
@@ -231,7 +231,6 @@ class Validator(BaseNeuron):
                 challenge_tasks = []
 
         valid_responses = [r for r in challenge_results if not r["error"]]
-
         n_valid = len(valid_responses)
         n_failures = len(challenge_results) - len(valid_responses)
         bt.logging.info(
@@ -239,14 +238,14 @@ class Validator(BaseNeuron):
         )
 
         bt.logging.info(f"Scoring {modality} challenge")
-        rewards = {}
-        if n_valid > 0:
-            bt.logging.success(valid_responses)
-            rewards = self.eval_engine.score_challenge(
-                valid_responses,
-                media_sample["label"],
-                modality,
-            )
+        rewards = self.eval_engine.score_challenge(
+            uids=[r["uid"] for r in challenge_results],
+            hotkeys=[r["hotkey"] for r in challenge_results],
+            predictions=[r["prediction"] for r in challenge_results],
+            errors=[r["error"] for r in challenge_results],
+            label=media_sample["label"],
+            challenge_modality=modality
+        )
 
         self.log_challenge_results(media_sample, challenge_results, rewards)
 


### PR DESCRIPTION
Simpler version of miner healthcheck for the proxy that relies on the cached state of the validator's miner tracker rather than adding additional endpoints/queries.