### PR TITLE
[testnet] wandb mask logging fix

### DIFF
--- a/bitmind/epistula.py
+++ b/bitmind/epistula.py
@@ -228,12 +228,12 @@ async def query_miner(
 
         if testnet_metadata:
             for k, v in testnet_metadata.items():
-                if MinerType.SEGMENTER and k == 'mask':
+                if miner_type == MinerType.SEGMENTER and k == 'mask':
                     resized_mask = cv2.resize(v, (128, 128))
                     _, buffer = cv2.imencode('.png', (resized_mask * 255).astype(np.uint8))
                     b64_mask = base64.b64encode(buffer).decode('utf-8')
                     headers["X-Testnet-mask"] = b64_mask
-                else:
+                elif k != 'mask':
                     headers[f"X-Testnet-{k}"] = str(v)
 
         async with session.post(

--- a/neurons/validator/proxy.py
+++ b/neurons/validator/proxy.py
@@ -708,10 +708,7 @@ class ValidatorProxy(BaseNeuron):
 
         if not valid_responses:
             bt.logging.warning("No valid responses received from miners")
-            raise HTTPException(
-                status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
-                detail="No valid predictions received",
-            )
+            return [], []
 
         predictions = np.array([r["prediction"] for r in valid_responses])
         uids = [r["uid"] for r in valid_responses]

--- a/neurons/validator/validator.py
+++ b/neurons/validator/validator.py
@@ -592,10 +592,15 @@ class Validator(BaseNeuron):
                 )
 
         for i in valid_indices:
+            pred = results['predictions'][i]
+            mtype = self.eval_engine.tracker.get_miner_type(uids[i])
+            if mtype == MinerType.SEGMENTER:
+                pred = f"shape: {np.array(pred).shape} min: {np.min(pred)} max: {np.max(pred)}"
+
             bt.logging.success(
                 f"UID: {results['miner_uids'][i]} | "
                 f"HOTKEY: {results['miner_hotkeys'][i]} | "
-                f"PRED: {results['predictions'][i]}"
+                f"PRED: {pred}"
             )
             video_metrics = {
                 "video_" + k: f"{v:.4f}"


### PR DESCRIPTION
Tried a bunch of different things to make downloading the resulting mask artifacts as efficient/easy as possible, but resorted to a simple approach that requires you to check a run's logged artifacts for an entry that matches the metadata in the run's history row. Cleanest and simplest solution with some extra overhead on the download side. 

predicted mask downloads:
https://gist.github.com/dylanuys/52c0be1c1a051c473b3b686f872322e0

