### PR TITLE
[testnet] Fix vali oom kills and add additional video verification checks

### DIFF
--- a/gas/cache/content_manager.py
+++ b/gas/cache/content_manager.py
@@ -728,81 +728,98 @@ class ContentManager:
 		hf_dataset_repos: dict, 
 		upload_batch_size: int, 
 		videos_per_archive: int,
-		validator_hotkey: str = None
+		validator_hotkey: str = None,
+		num_batches: int = 1
 	):
 		"""
 		Upload unuploaded media from database to HuggingFace, separated by modality.
 		Only uploads verified miner media or validator-generated media.
+
+		Args:
+			num_batches: Number of batches to process in this upload cycle (default: 1)
 		"""
-		try:			
-			#  prioritize verified miner media, then fill with validator media
-			media_by_modality = {}
-			total_found = 0
+		try:
+			if num_batches is None or num_batches < 1:
+				bt.logging.warning(f"Invalid num_batches value: {num_batches}, using default of 1")
+				num_batches = 1
 			
-			for modality in ["image", "video"]:
-				# prioritize all verified miner media
-				verified_miner_media = self.content_db.get_unuploaded_media(
-					limit=None, 
-					modality=modality, 
-					verified_only=True
-				)
-				
-				# Fill remaining slots with any unuploaded validator media
-				remaining_slots = max(0, upload_batch_size - len(verified_miner_media))
-				remaining_media = []
-				if remaining_slots > 0:
-					remaining_media = self.content_db.get_unuploaded_media(
-						limit=remaining_slots, 
+			total_uploaded_all_batches = 0
+
+			for batch_num in range(num_batches):
+				bt.logging.info(f"Processing upload batch {batch_num + 1}/{num_batches}")
+
+				#  prioritize verified miner media, then fill with validator media
+				media_by_modality = {}
+				total_found = 0
+
+				for modality in ["image", "video"]:
+					# prioritize verified miner media up to batch size
+					verified_miner_media = self.content_db.get_unuploaded_media(
+						limit=upload_batch_size, 
 						modality=modality, 
-						skip_verified=True
+						verified_only=True
 					)
 
-				unuploaded_media = verified_miner_media + remaining_media
-				media_by_modality[modality] = unuploaded_media
-				total_found += len(unuploaded_media)
+					# Fill remaining slots with any unuploaded validator media
+					remaining_slots = max(0, upload_batch_size - len(verified_miner_media))
+					remaining_media = []
+					if remaining_slots > 0:
+						remaining_media = self.content_db.get_unuploaded_media(
+							limit=remaining_slots, 
+							modality=modality, 
+							skip_verified=True
+						)
+
+					unuploaded_media = verified_miner_media + remaining_media
+					media_by_modality[modality] = unuploaded_media
+					total_found += len(unuploaded_media)
+
+					bt.logging.info(
+						f"{modality}: {len(verified_miner_media)} verified miner + "
+						f"{len(remaining_media)} validator = {len(unuploaded_media)} total"
+					)
+
+				if total_found == 0:
+					bt.logging.info(f"No more unuploaded media found after {batch_num} batches")
+					break
 
 				bt.logging.info(
-					f"{modality}: {len(verified_miner_media)} verified miner + "
-					f"{len(remaining_media)} validator = {len(unuploaded_media)} total"
+					f"Batch {batch_num + 1}: Found {total_found} unuploaded media files to upload "
+					f"({len(media_by_modality['image'])} images, {len(media_by_modality['video'])} videos)"
 				)
-			
-			if total_found == 0:
-				bt.logging.debug("No unuploaded media found in database")
-				return
 
-			bt.logging.info(
-				f"Found {total_found} unuploaded media files to upload to HuggingFace "
-				f"({len(media_by_modality['image'])} images, {len(media_by_modality['video'])} videos)"
-			)
+				all_successfully_processed_ids = []
 
-			all_successfully_processed_ids = []
+				if media_by_modality['image']:
+					uploaded_ids = upload_images_to_hf(
+						media_entries=media_by_modality['image'],
+						hf_token=hf_token,
+						dataset_repo=hf_dataset_repos['image'],
+						validator_hotkey=validator_hotkey
+					)
+					all_successfully_processed_ids.extend(uploaded_ids)
 
-			if media_by_modality['image']:
-				uploaded_ids = upload_images_to_hf(
-					media_entries=media_by_modality['image'],
-					hf_token=hf_token,
-					dataset_repo=hf_dataset_repos['image'],
-					validator_hotkey=validator_hotkey
-				)
-				all_successfully_processed_ids.extend(uploaded_ids)
+				if media_by_modality['video']:
+					uploaded_ids = upload_videos_to_hf(
+						media_entries=media_by_modality['video'],
+						hf_token=hf_token,
+						dataset_repo=hf_dataset_repos['video'],
+						videos_per_archive=videos_per_archive,
+						validator_hotkey=validator_hotkey
+					)
+					all_successfully_processed_ids.extend(uploaded_ids)
 
-			if media_by_modality['video']:
-				uploaded_ids = upload_videos_to_hf(
-					media_entries=media_by_modality['video'],
-					hf_token=hf_token,
-					dataset_repo=hf_dataset_repos['video'],
-					videos_per_archive=videos_per_archive,
-					validator_hotkey=validator_hotkey
-				)
-				all_successfully_processed_ids.extend(uploaded_ids)
+				# Mark all successfully uploaded media as uploaded in db
+				if all_successfully_processed_ids:
+					success = self.mark_media_uploaded(all_successfully_processed_ids)
+					if success:
+						bt.logging.info(f"Batch {batch_num + 1}: Marked {len(all_successfully_processed_ids)} entries as uploaded in database")
+						total_uploaded_all_batches += len(all_successfully_processed_ids)
+					else:
+						bt.logging.warning(f"Batch {batch_num + 1}: Failed to mark media as uploaded in database")
 
-			# Mark all successfully uploaded media as uploaded in db
-			if all_successfully_processed_ids:
-				success = self.mark_media_uploaded(all_successfully_processed_ids)
-				if success:
-					bt.logging.info(f"Marked {len(all_successfully_processed_ids)} entries as uploaded in database")
-				else:
-					bt.logging.warning("Failed to mark media as uploaded in database")
+			if total_uploaded_all_batches > 0:
+				bt.logging.info(f"✅ Upload cycle complete: {total_uploaded_all_batches} total files uploaded across {batch_num + 1} batches")
 
 		except Exception as e:
 			bt.logging.error(f"Error uploading batch to HuggingFace: {e}")

--- a/gas/config.py
+++ b/gas/config.py
@@ -510,10 +510,17 @@ def add_generation_service_args(parser):
     )
 
     parser.add_argument(
+        "--upload-num-batches",
+        type=int,
+        help="Number of upload batches to process per cycle",
+        default=5,
+    )
+
+    parser.add_argument(
         "--videos-per-archive",
         type=int,
         help="Maximum number of videos per archive file (keeps archive size manageable)",
-        default=25,
+        default=150,
     )
 
     # Shared source-limit args

--- a/gas/config.py
+++ b/gas/config.py
@@ -506,7 +506,7 @@ def add_generation_service_args(parser):
         "--upload-batch-size",
         type=int,
         help="Maximum number of media files to upload to HuggingFace per batch",
-        default=50,
+        default=500,
     )
 
     parser.add_argument(

--- a/gas/generation/prompt_generator.py
+++ b/gas/generation/prompt_generator.py
@@ -61,29 +61,52 @@ class PromptGenerator:
 
     def load_vlm(self) -> None:
         """
-        Load the vision-language model for image annotation.
+        Load the vision-language model for image annotation with local-first loading.
         """
         bt.logging.debug(f"Loading caption generation model {self.vlm_name}")
-        self.vlm_processor = Blip2Processor.from_pretrained(
-            self.vlm_name, torch_dtype=torch.float32
-        )
-        self.vlm = Blip2ForConditionalGeneration.from_pretrained(
-            self.vlm_name, torch_dtype=torch.float32
-        )
+
+        try:
+            bt.logging.info(f"Attempting to load {self.vlm_name} from local cache...")
+            self.vlm_processor = Blip2Processor.from_pretrained(
+                self.vlm_name, torch_dtype=torch.float32, local_files_only=True
+            )
+            self.vlm = Blip2ForConditionalGeneration.from_pretrained(
+                self.vlm_name, torch_dtype=torch.float32, local_files_only=True
+            )
+        except (OSError, ValueError) as e:
+            bt.logging.info(f"Model not in local cache, downloading from HuggingFace...")
+            self.vlm_processor = Blip2Processor.from_pretrained(
+                self.vlm_name, torch_dtype=torch.float32
+            )
+            self.vlm = Blip2ForConditionalGeneration.from_pretrained(
+                self.vlm_name, torch_dtype=torch.float32
+            )
+        
         self.vlm.to(self.device)
         bt.logging.info(f"Loaded image annotation model {self.vlm_name}")
 
     def load_llm(self) -> None:
         """
-        Load the language model for text moderation.
+        Load the language model for text moderation with local-first loading.
         """
         bt.logging.debug(f"Loading caption moderation model {self.llm_name}")
         m = re.match(r"cuda:(\d+)", self.device)
         gpu_id = int(m.group(1)) if m else 0
-        llm = AutoModelForCausalLM.from_pretrained(
-            self.llm_name, torch_dtype=torch.bfloat16, device_map={"": gpu_id}
-        )
-        tokenizer = AutoTokenizer.from_pretrained(self.llm_name)
+
+        try:
+            bt.logging.info(f"Attempting to load {self.llm_name} from local cache...")
+            llm = AutoModelForCausalLM.from_pretrained(
+                self.llm_name, torch_dtype=torch.bfloat16, device_map={"": gpu_id},
+                local_files_only=True
+            )
+            tokenizer = AutoTokenizer.from_pretrained(self.llm_name, local_files_only=True)
+        except (OSError, ValueError) as e:
+            bt.logging.info(f"Model not in local cache, downloading from HuggingFace...")
+            llm = AutoModelForCausalLM.from_pretrained(
+                self.llm_name, torch_dtype=torch.bfloat16, device_map={"": gpu_id}
+            )
+            tokenizer = AutoTokenizer.from_pretrained(self.llm_name)
+
         self.llm = pipeline("text-generation", model=llm, tokenizer=tokenizer)
         bt.logging.info(f"Loaded caption moderation model {self.llm_name}")
 

--- a/neurons/validator/services/generator_service.py
+++ b/neurons/validator/services/generator_service.py
@@ -81,8 +81,9 @@ class GeneratorService:
             "image": f"{self.hf_org}/generated-images",
             "video": f"{self.hf_org}/generated-videos",
         }
-        self.upload_batch_size = getattr(config, "upload_batch_size", 50)
-        self.videos_per_archive = getattr(config, "videos_per_archive", 25)
+        self.upload_batch_size = config.upload_batch_size
+        self.upload_num_batches = config.upload_num_batches
+        self.videos_per_archive = config.videos_per_archive
 
         # third party generative services
         self.tp_generators = {"nano_banana": nano_banana.generate_image}
@@ -235,11 +236,12 @@ class GeneratorService:
                 self._verify_miner_media(clip_batch_size=32)
 
                 # Upload batch of miner/validator generated media to HuggingFace
-                bt.logging.info("Beginning hf batch upload")
+                bt.logging.info(f"Beginning hf batch upload cycle ({self.upload_num_batches} batches of {self.upload_batch_size} files per modality)")
                 self.content_manager.upload_batch_to_huggingface(
                     hf_token=self.hf_token,
                     hf_dataset_repos=self.hf_dataset_repos,
                     upload_batch_size=self.upload_batch_size,
+                    num_batches=self.upload_num_batches,
                     videos_per_archive=self.videos_per_archive,
                     validator_hotkey=self.validator_wallet.hotkey.ss58_address,
                 )
@@ -440,7 +442,7 @@ class GeneratorService:
             error_results = [r for r in results if r.verification_score is None]
             if error_results:
                 bt.logging.warning(
-                    f"[GENERATOR-SEdRVICE] {len(error_results)} verification processing errors"
+                    f"[GENERATOR-SERVICE] {len(error_results)} verification processing errors"
                 )
 
             failed_results = [


### PR DESCRIPTION
- Reworked validator HF uploads to avoid trying to upload too many small archive files -- now submits 5 batches of up to 500 media files per batch, 150 videos max per archive. 
- Additional video verification checks (too few frames, repeated frames, corrupt video file)
- Avoid HF api calls when certain models are already cached locally (blip, hunyuan, janus, animatedifflightning)