### PR TITLE
Fix burn rate exceeding 70%: Exclude special UIDs from normalization, handle edge cases

### DIFF
--- a/neurons/validator/validator.py
+++ b/neurons/validator/validator.py
@@ -177,7 +177,12 @@ class Validator(BaseNeuron):
         """
         bt.logging.info(f"Updating scores at block {block}")
         generator_uids = await self.update_scores()
-
+        
+        # FIX: Handle None/empty generator_uids
+        if generator_uids is None:
+            generator_uids = []
+            bt.logging.warning("No generator rewards available; using empty generator_uids")
+        
         async with self._state_lock:
             bt.logging.debug("set_weights() acquired state lock")
             try:
@@ -193,16 +198,8 @@ class Validator(BaseNeuron):
                         "responses from miners, or a bug in your reward functions."
                     )
 
-                norm = np.ones_like(self.scores)
-                norm[generator_uids] = np.linalg.norm(self.scores[generator_uids], ord=1)
-
-                if np.any(norm == 0) or np.isnan(norm).any():
-                    norm = np.ones_like(norm)  # Avoid division by zero or NaN
-
-                normed_weights = self.scores / norm
-
-                # discriminator rewards distributed only upon performance improvements on benchmark exam
-                burn_pct = 0.7
+                # FIX: Get special UIDs first
+                burn_pct = .7  # TODO: config in next change
                 burn_uid = self.subtensor.get_uid_for_hotkey_on_subnet(
                     hotkey_ss58=SS58_ADDRESSES["burn"],
                     netuid=self.config.netuid, 
@@ -219,18 +216,35 @@ class Validator(BaseNeuron):
                      netuid=self.config.netuid, 
                      block=block)
 
-                # .8 to discriminators, .2 to generators for now
-                g_pct = (1. - d_pct)
-                normed_weights = np.array([
-                    (1 - burn_pct) * g_pct  * v
-                    for v in normed_weights
-                ])
+                special_uids = {burn_uid, image_escrow_uid, video_escrow_uid}
+                bt.logging.info(f"Special UIDs to exclude: {special_uids}")
+
+                # Compute norm excluding specials
+                norm = np.ones_like(self.scores)
+                active_uids = [uid for uid in generator_uids if uid not in special_uids]
+                if active_uids:
+                    norm[active_uids] = np.linalg.norm(self.scores[active_uids], ord=1)
                 
+                if np.any(norm == 0) or np.isnan(norm).any():
+                    norm = np.ones_like(norm)
+
+                normed_weights = self.scores / norm
+
+                # FIX: Scale ONLY active (non-special) weights
+                g_pct = (1. - d_pct)
+                active_mask = np.array([uid not in special_uids for uid in range(len(normed_weights))])
+                normed_weights[active_mask] *= (1 - burn_pct) * g_pct
+
+                # Set special weights (only once, no prior scaling)
                 normed_weights[burn_uid] = burn_pct
                 normed_weights[image_escrow_uid] = (1 - burn_pct) * d_pct / 2
                 normed_weights[video_escrow_uid] = (1 - burn_pct) * d_pct / 2
                 bt.logging.info(f"Image discriminator escrow UID: {image_escrow_uid}")
                 bt.logging.info(f"Video discriminator escrow UID: {video_escrow_uid}")
+                # Verify burn rate
+                total_weight = np.sum(normed_weights)
+                actual_burn_rate = normed_weights[burn_uid] / total_weight if total_weight > 0 else 0
+                bt.logging.info(f"Total weight sum: {total_weight:.4f}, Actual burn rate: {actual_burn_rate:.4f} (target: {burn_pct})")
 
                 self.set_weights_fn(
                     self.wallet, self.metagraph, self.subtensor, (uids, normed_weights)


### PR DESCRIPTION
**Problem**: Burn rate >70% (target: 70%); crashes on empty rewards; hardcoded pct inflexible.

**Root Cause**: 
- Special UIDs (burn/escrows) included in generator norm/scaling → skews weights.
- `update_scores()` returns `None` → indexing crash.

**Changes**:
- Exclude specials from `norm`/`scaling` in `set_weights`; add burn rate log.
- Handle `generator_uids=None` → `[]`.

**Test**: Run validator → logs show `Actual burn rate: 0.7000`; tweak env vars.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Exclude burn/escrow UIDs from weight normalization/scaling and guard against None generator_uids, with added burn-rate logging.
> 
> - **Validator (`neurons/validator/validator.py`)**:
>   - **Weight computation**:
>     - Fetch special UIDs (`burn`, `image_escrow`, `video_escrow`) first and exclude them from normalization/scaling.
>     - Compute `norm` only over active generator UIDs; guard against zero/NaN norms.
>     - Scale only active (non-special) weights by `(1 - burn_pct) * g_pct`; set specials explicitly: `burn_pct`, and split discriminator escrow weights.
>     - Log special UIDs, total weight sum, and actual burn rate for verification.
>   - **Robustness**:
>     - Handle `generator_uids is None` by defaulting to `[]` to avoid indexing crashes.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a842cc1cbfc5c0d0de7c083bb9b3ba998fe2935d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->



Contribution by Gittensor, learn more at https://gittensor.io/