### PR TITLE
doc: update gen_miner env template and readme

### DIFF
--- a/.env.gen_miner.template
+++ b/.env.gen_miner.template
@@ -27,6 +27,9 @@ OPENAI_API_KEY=
 # OpenRouter (multi-model access)
 OPEN_ROUTER_API_KEY=
 
+# StabilityAI
+STABILITY_API_KEY=
+
 # Hugging Face (for model downloads)
 HUGGINGFACE_HUB_TOKEN=
 
@@ -87,4 +90,5 @@ BT_LOGGING_LEVEL=INFO
 # Get API keys:
 # - OpenAI: https://platform.openai.com/api-keys
 # - OpenRouter: https://openrouter.ai/keys  
+# - StabilityAI: https://platform.stability.ai/account/keys
 # - Hugging Face: https://huggingface.co/settings/tokens

--- a/docs/Generative-Mining.md
+++ b/docs/Generative-Mining.md
@@ -49,6 +49,7 @@ BT_LOGGING_LEVEL=info
 # Configure API keys for external services, or use local generation
 OPENAI_API_KEY=your_openai_api_key
 OPEN_ROUTER_API_KEY=your_openrouter_api_key
+STABILITY_API_KEY=your_stabilityai_api_key
 
 # Optional Settings  
 AUTO_UPDATE=false
@@ -83,6 +84,13 @@ Generative miners support multiple generation approaches. You can choose between
 - **Supported**: Image generation
 - **Models**: Google Gemini Flash Image Preview, various other models
 - **Website**: [OpenRouter.ai](https://openrouter.ai)
+
+### StabilityAI Service
+- **API Key**: `STABILITY_API_KEY`
+- **Supported**: Image generation
+- **Models**: SD 3.5 variant models
+- **Website**: [Stability.ai](https://stability.ai/)
+- **Pricing**: ~$0.0035/image (SD 3.5 Medium)
 
 ### Local Service (Open Source Models)
 - **API Key**: None required


### PR DESCRIPTION
This pr updates gen_miner env template and readme for the new service added. #303 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds `STABILITY_API_KEY` to the env template and documents the StabilityAI service in the Generative Mining guide.
> 
> - **Docs**:
>   - Add StabilityAI service section in `docs/Generative-Mining.md` detailing `STABILITY_API_KEY`, supported image generation, SD 3.5 models, website, and pricing.
> - **Config**:
>   - Add `STABILITY_API_KEY=` to `.env.gen_miner.template`.
>   - Include StabilityAI API key link in the template’s API keys section.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b9ccf0270bd71dd7aa8ffaa8e174b02eb55ad98f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

Contribution by Gittensor, learn more at https://gittensor.io/