### PR TITLE
fix cleanup old media files and add some gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -76,3 +76,7 @@ downloaded_models/*
 generated_content/*
 
 wandb/*
+
+node_modules/
+package-lock.json
+package.json

--- a/gas/config.py
+++ b/gas/config.py
@@ -173,6 +173,13 @@ def add_miner_args(parser):
     )
 
     parser.add_argument(
+        "--miner.file-max-age-hours",
+        type=float,
+        default=1.0,
+        help="Maximum age (hours) of files in output directory before deletion",
+    )
+
+    parser.add_argument(
         "--miner.worker-threads",
         type=int,
         default=2,


### PR DESCRIPTION
# 🗑️ Add Automatic File Cleanup for Generative Miners

## Problem
Generative miners save generated images, videos, and JSON metadata files to disk temporarily, but these files were never deleted. This caused storage to fill up over time.

## Solution
Added automatic cleanup functionality to the existing cleanup thread that removes old files from the output directory.

## Changes Made

### 1. Enhanced Cleanup Thread ([neurons/generator/miner.py](cci:7://file:///d:/Ninja_Work/Git_work/bitmind-subnet/neurons/generator/miner.py:0:0-0:0))
- Modified [_cleanup_loop()](cci:1://file:///d:/Ninja_Work/Git_work/bitmind-subnet/neurons/generator/miner.py:262:4-282:44) to clean up both in-memory tasks AND disk files
- Added [_cleanup_old_files()](cci:1://file:///d:/Ninja_Work/Git_work/bitmind-subnet/neurons/generator/miner.py:284:4-325:28) method to delete old media files
- Only deletes specific file types: `.png`, `.mp4`, `.json`, `.jpg`, `.jpeg`, `.gif`, `.webm`, `.avi`
- Protects directories (like [logs/](cci:1://file:///d:/Ninja_Work/Git_work/bitmind-subnet/gas/cli.py:305:0-318:52)) and other file types

### 2. Configuration ([gas/config.py](cci:7://file:///d:/Ninja_Work/Git_work/bitmind-subnet/gas/config.py:0:0-0:0))
- Added `--miner.file-max-age-hours` parameter (default: 1.0 hour)
- Uses existing `--miner.cleanup-interval` for cleanup frequency (default: 3600 seconds)

## Behavior

**Default Settings:**
- Cleanup runs every 1 hour
- Deletes files older than 1 hour
- Logs cleanup activity: `🗑️ Deleted 12 old files from disk (older than 1.0h)`

**Configuration Example:**
```bash
# In .env.gen_miner
MINER_CLEANUP_INTERVAL=3600         # Cleanup frequency (seconds)
MINER_FILE_MAX_AGE_HOURS=1          # Delete files older than X hours
```

Note: I also added some gitignore so please check it as well.

Contribution by Gittensor, learn more at https://gittensor.io
