### PR TITLE
Docker env file consolidation

### DIFF
--- a/.env.validator.template
+++ b/.env.validator.template
@@ -16,10 +16,13 @@ CHAIN_ENDPOINT=wss://entrypoint-finney.opentensor.ai:443
 CALLBACK_PORT=10525
 #EXTERNAL_CALLBACK_PORT=  # Optional
 
-# Cache config
+# Cache config (non-Docker: these apply; in Docker the entrypoint overrides to volume paths)
 SN34_CACHE_DIR=~/.cache/sn34
 HF_HOME=~/.cache/huggingface
 HEARTBEAT=true
+
+# Docker only: host path for wallet bind-mount (used by docker-compose for volume)
+WALLET_PATH=~/.bittensor/wallets
 
 # Generator config
 GENERATION_BATCH_SIZE=3
@@ -35,21 +38,23 @@ AUTO_UPDATE=true
 #START_DATA=true
 
 # ── Docker-specific notes ──────────────────────────────────────────────────
-# When running via Docker (docker-compose.yml):
+# Use .env.validator as the single source of truth: run Compose with
+#   --env-file .env.validator
+# so this file drives both container env and Compose variable substitution
+# (e.g. WALLET_PATH, CALLBACK_PORT). Example:
+#   docker compose --env-file .env.validator up -d
 #
-# - SN34_CACHE_DIR and HF_HOME are volume-mounted inside the container at
-#   /root/.cache/sn34 and /root/.cache/huggingface respectively. The values
-#   above are overridden by the container entrypoint.
+# - SN34_CACHE_DIR / HF_HOME: In Docker the container entrypoint overrides
+#   these to /root/.cache/sn34 and /root/.cache/huggingface (volume-mounted).
 #
 # - AUTO_UPDATE is always disabled in Docker. To update, rebuild the image:
-#     docker compose build && docker compose up -d
+#   docker compose --env-file .env.validator build && docker compose --env-file .env.validator up -d
 #
-# - Wallet files are bind-mounted from the host. Set WALLET_PATH in your
-#   shell environment (or .env file) to point to your host wallet directory:
-#     export WALLET_PATH=~/.bittensor/wallets
+# - WALLET_PATH: Set in this file (see above). Compose uses it for the wallet
+#   bind-mount only when you pass --env-file .env.validator.
 #
 # - NETUID is auto-derived from CHAIN_ENDPOINT. Override by setting NETUID
 #   explicitly if using a custom endpoint.
 #
 # - Logs from all 3 services stream to Docker stdout/stderr:
-#     docker compose logs -f validator
+#   docker compose logs -f validator

--- a/.env.validator.template
+++ b/.env.validator.template
@@ -47,8 +47,9 @@ AUTO_UPDATE=true
 # - SN34_CACHE_DIR / HF_HOME: In Docker the container entrypoint overrides
 #   these to /root/.cache/sn34 and /root/.cache/huggingface (volume-mounted).
 #
-# - AUTO_UPDATE is always disabled in Docker. To update, rebuild the image:
-#   docker compose --env-file .env.validator build && docker compose --env-file .env.validator up -d
+# - AUTO_UPDATE is always disabled in Docker. To update manually, rebuild and up. For automatic
+#   updates, use a cron job that runs docker/autoupdate.sh (checks VERSION same as PM2 autoupdate,
+#   then git pull + build + up). Example (every 5 min): */5 * * * * /path/to/bitmind-subnet/docker/autoupdate.sh >> /var/log/bitmind-docker-update.log 2>&1
 #
 # - WALLET_PATH: Set in this file (see above). Compose uses it for the wallet
 #   bind-mount only when you pass --env-file .env.validator.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,3 +1,5 @@
+# Run with: docker compose --env-file .env.validator up -d
+# so .env.validator drives both container env and variable substitution (WALLET_PATH, CALLBACK_PORT).
 services:
   validator:
     build: .

--- a/docker/autoupdate.sh
+++ b/docker/autoupdate.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+# Cron-friendly script: check remote VERSION (same as Python/PM2 autoupdate),
+# and if newer, git pull + rebuild image + docker compose up.
+# Usage: run from repo root, or set REPO_DIR. Optional: BRANCH=main, ENV_FILE=.env.validator.
+# Example crontab (every 5 min): */5 * * * * /path/to/bitmind-subnet/docker/autoupdate.sh >> /var/log/bitmind-docker-update.log 2>&1
+
+set -euo pipefail
+
+REPO_DIR="${REPO_DIR:-$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)}"
+BRANCH="${BRANCH:-main}"
+ENV_FILE="${ENV_FILE:-.env.validator}"
+VERSION_URL="https://raw.githubusercontent.com/BitMind-AI/bitmind-subnet/${BRANCH}/VERSION"
+
+log() { echo "[$(date -u +%Y-%m-%dT%H:%M:%SZ)] $*"; }
+
+cd "$REPO_DIR"
+LOCAL_VERSION_FILE="$REPO_DIR/VERSION"
+
+if [[ ! -f "$LOCAL_VERSION_FILE" ]]; then
+  log "ERROR: VERSION not found at $LOCAL_VERSION_FILE"
+  exit 1
+fi
+
+local_version=$(cat "$LOCAL_VERSION_FILE" | tr -d '\n\r ')
+remote_version=$(curl -sL --connect-timeout 10 --max-time 30 \
+  -H "Cache-Control: no-cache, no-store, must-revalidate" \
+  -H "Pragma: no-cache" \
+  "$VERSION_URL?t=$(date +%s)" | tr -d '\n\r ')
+
+if [[ -z "$remote_version" ]]; then
+  log "WARN: Could not fetch remote VERSION from $VERSION_URL"
+  exit 0
+fi
+
+# Compare x.y.z (same semantics as Python autoupdater: tuple comparison)
+latest=$(printf '%s\n%s\n' "$local_version" "$remote_version" | sort -t. -k1,1n -k2,2n -k3,3n | tail -1)
+if [[ "$latest" != "$remote_version" ]] || [[ "$local_version" == "$remote_version" ]]; then
+  log "No update: local=$local_version remote=$remote_version"
+  exit 0
+fi
+
+log "New version: $remote_version (local=$local_version). Pulling and rebuilding..."
+git pull
+
+# Verify VERSION after pull
+new_local=$(cat "$LOCAL_VERSION_FILE" | tr -d '\n\r ')
+if [[ "$new_local" != "$remote_version" ]]; then
+  log "ERROR: After git pull, local VERSION=$new_local != remote=$remote_version"
+  exit 1
+fi
+
+log "Rebuilding image and recreating container..."
+# Use --no-cache to ensure a clean build; omit for faster incremental builds.
+docker compose --env-file "$ENV_FILE" build --no-cache
+docker compose --env-file "$ENV_FILE" up -d
+
+log "Update to $remote_version complete."
+exit 0

--- a/docs/Validating.md
+++ b/docs/Validating.md
@@ -174,7 +174,9 @@ docker compose exec validator bash
 
 ### Updating
 
-Auto-update is disabled in Docker (containers are immutable). To update to a new version:
+Auto-update is disabled inside the container (containers are immutable). To update to a new version:
+
+**Manual:** rebuild and recreate the container:
 
 ```bash
 git pull
@@ -182,4 +184,10 @@ docker compose --env-file .env.validator build
 docker compose --env-file .env.validator up -d
 ```
 
-This rebuilds the image with the latest code while preserving all cached data in the Docker volumes.
+**Automatic (cron):** use the same VERSION check as the PM2 autoupdater. From the repo root, run `docker/autoupdate.sh`; it fetches the remote `VERSION` from the branch (default `main`), compares to your local `VERSION`, and if a newer version exists it runs `git pull`, rebuilds the image, and brings the stack up. Example crontab (every 5 minutes; check is lightweight when no update):
+
+```bash
+*/5 * * * * /path/to/bitmind-subnet/docker/autoupdate.sh >> /var/log/bitmind-docker-update.log 2>&1
+```
+
+Optional env: `REPO_DIR` (repo root), `BRANCH` (default `main`), `ENV_FILE` (default `.env.validator`). This rebuilds the image with the latest code while preserving all cached data in the Docker volumes.


### PR DESCRIPTION
- autupdate via cron, check sn repo for new `VERSION`
- rely on `.env.validator` as single source of truth for env vars and docker overrides  so that validators don't have to set shell vars manually.