### PR TITLE
fix: replace bare except clauses with except Exception

### DIFF
--- a/gas/scraping/google.py
+++ b/gas/scraping/google.py
@@ -368,7 +368,7 @@ class GoogleScraper(BaseScraper):
                                     break
                             if full_size_img:
                                 break
-                        except:
+                        except Exception:
                             continue
 
                     if full_size_img and full_size_img not in image_urls:
@@ -385,7 +385,7 @@ class GoogleScraper(BaseScraper):
                         time.sleep(random.uniform(0.2, 0.8))
                         close_button.click()
                         time.sleep(random.uniform(0.3, 0.7))
-                    except:
+                    except Exception:
                         pass
 
                 except Exception as e:

--- a/gas/utils/chain_model_metadata_store.py
+++ b/gas/utils/chain_model_metadata_store.py
@@ -67,7 +67,7 @@ class ChainModelMetadataStore:
         bt.logging.info(f"chain_str: {chain_str}")
         try:
             model_id = ModelId.from_compressed_str(chain_str)
-        except:
+        except Exception:
             bt.logging.trace(
                 f"Failed to parse the metadata on the chain for hotkey {hotkey}."
             )

--- a/gas/utils/huggingface_uploads.py
+++ b/gas/utils/huggingface_uploads.py
@@ -141,7 +141,7 @@ def upload_media_to_hf(
 
         try:
             create_repo(dataset_repo, repo_type="dataset", exist_ok=True, token=hf_token)
-        except:
+        except Exception:
             pass
 
         archive_operations = []
@@ -177,7 +177,7 @@ def upload_media_to_hf(
             for temp_file in all_temp_files:
                 try:
                     os.unlink(temp_file)
-                except:
+                except Exception:
                     pass
 
         return successfully_processed_ids
@@ -582,7 +582,7 @@ def create_image_archives(
         for temp_file in temp_files_to_cleanup:
             try:
                 os.unlink(temp_file)
-            except:
+            except Exception:
                 pass
         raise
 
@@ -661,7 +661,7 @@ def create_video_archives(
         for temp_file in temp_files_to_cleanup:
             try:
                 os.unlink(temp_file)
-            except:
+            except Exception:
                 pass
         raise
 

--- a/neurons/validator/services/generator_service.py
+++ b/neurons/validator/services/generator_service.py
@@ -674,7 +674,7 @@ class GeneratorService:
             try:
                 from gas.verification import clear_clip_models
                 clear_clip_models()
-            except:
+            except Exception:
                 pass
 
     def _cleanup(self):


### PR DESCRIPTION
Replaces bare `except:` with `except Exception:` across 4 files. Bare excepts can catch KeyboardInterrupt and SystemExit, which is usually unintended.