### PR TITLE
Count generator challenge outcomes

### DIFF
--- a/gas/cache/__init__.py
+++ b/gas/cache/__init__.py
@@ -1,7 +1,21 @@
-from .content_manager import ContentManager
-from .media_storage import MediaStorage
-from .types import Media
-from .content_db import ContentDB
-from .types import PromptEntry, MediaEntry
-
 __all__ = ["ContentManager", "MediaStorage", "ContentDB", "PromptEntry", "MediaEntry", "Media"]
+
+
+def __getattr__(name):
+    if name == "ContentManager":
+        from .content_manager import ContentManager
+        return ContentManager
+    if name == "MediaStorage":
+        from .media_storage import MediaStorage
+        return MediaStorage
+    if name == "ContentDB":
+        from .content_db import ContentDB
+        return ContentDB
+    if name in {"Media", "PromptEntry", "MediaEntry"}:
+        from .types import Media, PromptEntry, MediaEntry
+        return {
+            "Media": Media,
+            "PromptEntry": PromptEntry,
+            "MediaEntry": MediaEntry,
+        }[name]
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/gas/cache/content_db.py
+++ b/gas/cache/content_db.py
@@ -10,7 +10,7 @@ import random
 
 import bittensor as bt
 
-from gas.cache.types import PromptEntry, MediaEntry
+from gas.cache.types import ChallengeOutcome, PromptEntry, MediaEntry
 from gas.types import Modality, MediaType, SOURCE_TYPE_TO_DB_NAME_FIELD, SourceType
 
 
@@ -165,6 +165,25 @@ class ContentDB:
             """
             )
 
+            conn.execute(
+                """
+                CREATE TABLE IF NOT EXISTS generator_challenge_outcomes (
+                    task_id TEXT PRIMARY KEY,
+                    uid INTEGER NOT NULL,
+                    hotkey TEXT NOT NULL,
+                    prompt_id TEXT NOT NULL,
+                    modality TEXT NOT NULL CHECK (modality IN ('image', 'video', 'audio')),
+                    status TEXT NOT NULL CHECK (status IN ('pending', 'stored', 'verified', 'failed')),
+                    failure_reason TEXT,
+                    media_id TEXT,
+                    created_at REAL NOT NULL,
+                    updated_at REAL NOT NULL,
+                    FOREIGN KEY (prompt_id) REFERENCES prompts (id),
+                    FOREIGN KEY (media_id) REFERENCES media (id)
+                )
+            """
+            )
+
             # Create indexes for better performance
             conn.execute(
                 "CREATE INDEX IF NOT EXISTS idx_prompts_content_type ON prompts (content_type)"
@@ -228,6 +247,21 @@ class ContentDB:
             )
             conn.execute(
                 "CREATE INDEX IF NOT EXISTS idx_miner_media_created_at ON miner_media (created_at)"
+            )
+            conn.execute(
+                "CREATE INDEX IF NOT EXISTS idx_challenge_outcomes_hotkey ON generator_challenge_outcomes (hotkey)"
+            )
+            conn.execute(
+                "CREATE INDEX IF NOT EXISTS idx_challenge_outcomes_uid ON generator_challenge_outcomes (uid)"
+            )
+            conn.execute(
+                "CREATE INDEX IF NOT EXISTS idx_challenge_outcomes_status ON generator_challenge_outcomes (status)"
+            )
+            conn.execute(
+                "CREATE INDEX IF NOT EXISTS idx_challenge_outcomes_updated_at ON generator_challenge_outcomes (updated_at)"
+            )
+            conn.execute(
+                "CREATE INDEX IF NOT EXISTS idx_challenge_outcomes_media_id ON generator_challenge_outcomes (media_id)"
             )
 
             # Add 'uploaded' column to media table if it doesn't exist (conditional migration)
@@ -319,6 +353,26 @@ class ContentDB:
             except Exception as e:
                 if "duplicate column name" not in str(e).lower() and "already exists" not in str(e).lower():
                     bt.logging.error(f"Unexpected error adding 'c2pa_issuer' column: {e}")
+
+            # Add task_id column for generation challenge outcome linkage (migration)
+            try:
+                conn.execute("ALTER TABLE media ADD COLUMN task_id TEXT")
+                bt.logging.info("Added 'task_id' column to media table")
+                conn.execute(
+                    "CREATE INDEX IF NOT EXISTS idx_media_task_id ON media (task_id)"
+                )
+                conn.commit()
+            except Exception as e:
+                if "duplicate column name" not in str(e).lower() and "already exists" not in str(e).lower():
+                    bt.logging.error(f"Unexpected error adding 'task_id' column: {e}")
+                else:
+                    try:
+                        conn.execute(
+                            "CREATE INDEX IF NOT EXISTS idx_media_task_id ON media (task_id)"
+                        )
+                        conn.commit()
+                    except Exception:
+                        pass
 
             # Add modality column to prompts table (migration)
             try:
@@ -494,6 +548,11 @@ class ContentDB:
                 if "c2pa_issuer" in row.keys() and row["c2pa_issuer"] is not None
                 else None
             ),
+            task_id=(
+                row["task_id"]
+                if "task_id" in row.keys() and row["task_id"] is not None
+                else None
+            ),
             created_at=row["created_at"],
             generation_args=(
                 json.loads(row["generation_args"]) if row["generation_args"] else None
@@ -528,6 +587,7 @@ class ContentDB:
         perceptual_hash: Optional[str] = None,
         c2pa_verified: Optional[bool] = None,
         c2pa_issuer: Optional[str] = None,
+        task_id: Optional[str] = None,
     ) -> str:
         media_id = str(uuid.uuid4())
         created_at = time.time()
@@ -542,8 +602,8 @@ class ContentDB:
                                  model_name, download_url, scraper_name, dataset_name, 
                                  dataset_source_file, dataset_index, uid, hotkey, verified,
                                  created_at, generation_args, mask_path, timestamp, resolution, 
-                                 file_size, format, perceptual_hash, c2pa_verified, c2pa_issuer)
-                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                                 file_size, format, perceptual_hash, c2pa_verified, c2pa_issuer, task_id)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
             """,
                 (
                     media_id,
@@ -571,6 +631,7 @@ class ContentDB:
                     perceptual_hash,
                     c2pa_verified,
                     c2pa_issuer,
+                    task_id,
                 ),
             )
             conn.commit()
@@ -703,6 +764,196 @@ class ContentDB:
             )
             return int(cursor.fetchone()[0])
 
+    def record_challenge_outcome(
+        self,
+        task_id: str,
+        uid: int,
+        hotkey: str,
+        prompt_id: str,
+        modality: str,
+        status: str = "pending",
+        failure_reason: Optional[str] = None,
+        media_id: Optional[str] = None,
+        created_at: Optional[float] = None,
+    ) -> bool:
+        """Insert or update a generation challenge outcome."""
+        try:
+            now = time.time()
+            created_at = created_at or now
+            with self._get_db_connection() as conn:
+                conn.execute(
+                    """
+                    INSERT INTO generator_challenge_outcomes (
+                        task_id, uid, hotkey, prompt_id, modality, status,
+                        failure_reason, media_id, created_at, updated_at
+                    )
+                    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                    ON CONFLICT(task_id) DO UPDATE SET
+                        uid = excluded.uid,
+                        hotkey = excluded.hotkey,
+                        prompt_id = excluded.prompt_id,
+                        modality = excluded.modality,
+                        status = excluded.status,
+                        failure_reason = excluded.failure_reason,
+                        media_id = COALESCE(excluded.media_id, generator_challenge_outcomes.media_id),
+                        updated_at = excluded.updated_at
+                    """,
+                    (
+                        task_id,
+                        uid,
+                        hotkey,
+                        prompt_id,
+                        modality,
+                        status,
+                        failure_reason,
+                        media_id,
+                        created_at,
+                        now,
+                    ),
+                )
+                conn.commit()
+            return True
+        except Exception as e:
+            bt.logging.error(f"Error recording challenge outcome for task {task_id}: {e}")
+            return False
+
+    def update_challenge_outcome(
+        self,
+        task_id: str,
+        status: str,
+        failure_reason: Optional[str] = None,
+        media_id: Optional[str] = None,
+    ) -> bool:
+        """Update an existing challenge outcome status."""
+        try:
+            with self._get_db_connection() as conn:
+                cursor = conn.execute(
+                    """
+                    UPDATE generator_challenge_outcomes
+                    SET status = ?,
+                        failure_reason = ?,
+                        media_id = COALESCE(?, media_id),
+                        updated_at = ?
+                    WHERE task_id = ?
+                    """,
+                    (status, failure_reason, media_id, time.time(), task_id),
+                )
+                conn.commit()
+                return cursor.rowcount > 0
+        except Exception as e:
+            bt.logging.error(f"Error updating challenge outcome for task {task_id}: {e}")
+            return False
+
+    def mark_challenge_outcome_for_media(
+        self,
+        media_id: str,
+        status: str,
+        failure_reason: Optional[str] = None,
+    ) -> bool:
+        """Update a challenge outcome using its stored media row."""
+        try:
+            with self._get_db_connection() as conn:
+                cursor = conn.execute(
+                    """
+                    UPDATE generator_challenge_outcomes
+                    SET status = ?,
+                        failure_reason = ?,
+                        media_id = COALESCE(media_id, ?),
+                        updated_at = ?
+                    WHERE media_id = ?
+                       OR task_id = (SELECT task_id FROM media WHERE id = ?)
+                    """,
+                    (status, failure_reason, media_id, time.time(), media_id, media_id),
+                )
+                conn.commit()
+                return cursor.rowcount > 0
+        except Exception as e:
+            bt.logging.error(f"Error updating challenge outcome for media {media_id}: {e}")
+            return False
+
+    def get_challenge_outcomes_last_n_hours(
+        self, lookback_hours: float = 2.0, limit: int = 1000
+    ) -> List[ChallengeOutcome]:
+        """Get terminal generation challenge outcomes from the last N hours."""
+        try:
+            cutoff_timestamp = time.time() - (lookback_hours * 3600)
+            if limit is None:
+                limit = 1000
+            limit = int(limit)
+            with self._get_db_connection() as conn:
+                conn.row_factory = sqlite3.Row
+                cursor = conn.execute(
+                    """
+                    SELECT * FROM generator_challenge_outcomes
+                    WHERE status IN ('verified', 'failed')
+                      AND updated_at >= ?
+                    ORDER BY updated_at DESC
+                    LIMIT ?
+                    """,
+                    (cutoff_timestamp, limit),
+                )
+                return [
+                    ChallengeOutcome(
+                        task_id=row["task_id"],
+                        uid=row["uid"],
+                        hotkey=row["hotkey"],
+                        prompt_id=row["prompt_id"],
+                        modality=row["modality"],
+                        status=row["status"],
+                        failure_reason=row["failure_reason"],
+                        media_id=row["media_id"],
+                        created_at=row["created_at"],
+                        updated_at=row["updated_at"],
+                    )
+                    for row in cursor.fetchall()
+                ]
+        except Exception as e:
+            bt.logging.error(f"Error getting recent challenge outcomes: {e}")
+            return []
+
+    def get_challenge_outcome_stats_last_n_hours(
+        self, lookback_hours: float = 2.0, limit: int = 1000
+    ) -> Dict[str, Dict[str, Any]]:
+        """Build reward stats from terminal challenge outcomes."""
+        outcomes = self.get_challenge_outcomes_last_n_hours(lookback_hours, limit)
+        miner_stats: Dict[str, Dict[str, Any]] = {}
+        for outcome in outcomes:
+            hotkey = outcome.hotkey
+            if hotkey not in miner_stats:
+                miner_stats[hotkey] = {
+                    "uid": outcome.uid,
+                    "verified_media_ids": [],
+                    "total_verified": 0,
+                    "total_failed": 0,
+                    "last_timestamp": outcome.updated_at,
+                }
+            if outcome.status == "verified":
+                miner_stats[hotkey]["total_verified"] += 1
+                if outcome.media_id:
+                    miner_stats[hotkey]["verified_media_ids"].append(outcome.media_id)
+            elif outcome.status == "failed":
+                miner_stats[hotkey]["total_failed"] += 1
+            if outcome.updated_at > miner_stats[hotkey]["last_timestamp"]:
+                miner_stats[hotkey]["last_timestamp"] = outcome.updated_at
+
+        verification_stats = {}
+        for hotkey, stats in miner_stats.items():
+            verified = stats["total_verified"]
+            failed = stats["total_failed"]
+            total_evaluated = verified + failed
+            pass_rate = (verified / total_evaluated) if total_evaluated > 0 else 0.0
+            verification_stats[hotkey] = {
+                "uid": stats["uid"],
+                "total_verified": verified,
+                "total_submissions": total_evaluated,
+                "total_failed": failed,
+                "total_evaluated": total_evaluated,
+                "pass_rate": pass_rate,
+                "media_ids": stats["verified_media_ids"],
+                "last_timestamp": stats["last_timestamp"],
+            }
+        return verification_stats
+
     def mark_miner_media_verified(self, media_id: str) -> bool:
         try:
             with self._get_db_connection() as conn:
@@ -713,7 +964,10 @@ class ContentDB:
                     (media_id,),
                 )
                 conn.commit()
-                return cursor.rowcount > 0
+                updated = cursor.rowcount > 0
+            if updated:
+                self.mark_challenge_outcome_for_media(media_id, "verified")
+            return updated
         except Exception as e:
             bt.logging.error(f"Error marking miner media as verified: {e}")
             return False
@@ -728,7 +982,12 @@ class ContentDB:
                     (media_id,),
                 )
                 conn.commit()
-                return cursor.rowcount > 0
+                updated = cursor.rowcount > 0
+            if updated:
+                self.mark_challenge_outcome_for_media(
+                    media_id, "failed", "clip_verification_failed"
+                )
+            return updated
         except Exception as e:
             bt.logging.error(f"Error marking miner media as failed verification: {e}")
             return False

--- a/gas/cache/content_manager.py
+++ b/gas/cache/content_manager.py
@@ -736,9 +736,16 @@ class ContentManager:
 	) -> Dict[str, Dict[str, Any]]:
 		"""Merge legacy media-based stats with challenge-outcome stats.
 
-		Post-deployment events appear in both sources. Use max() rather than
-		sum() to avoid double-counting: legacy always includes outcome's
-		events plus any pre-deployment media verified in the same window.
+		Post-deployment, verified events appear in both sources (same CLIP
+		pass recorded in both media and outcome). Use max() to avoid
+		double-counting those.
+
+		Failed events partially overlap (CLIP fails) but outcome also tracks
+		pre-storage rejections that never create a media row. Use sum() so
+		pre-storage rejections are always counted — the CLIP-fail overlap
+		is a minor pessimism that self-resolves when the transition window
+		(≤4h lookback) elapses and outcome >= legacy for all event types.
+
 		Miners in only one source pass through unchanged.
 		"""
 		merged = {}
@@ -751,9 +758,9 @@ class ContentManager:
 				legacy.get("total_verified", 0),
 				outcome.get("total_verified", 0),
 			)
-			failed = max(
-				legacy.get("total_failed", 0),
-				outcome.get("total_failed", 0),
+			failed = (
+				legacy.get("total_failed", 0)
+				+ outcome.get("total_failed", 0)
 			)
 			total_evaluated = verified + failed
 			pass_rate = (verified / total_evaluated) if total_evaluated > 0 else 0.0

--- a/gas/cache/content_manager.py
+++ b/gas/cache/content_manager.py
@@ -770,8 +770,12 @@ class ContentManager:
 				outcome.get("last_timestamp", 0) or 0,
 			)
 
+			uid_legacy = legacy.get("uid")
+			uid_outcome = outcome.get("uid")
+			uid = uid_outcome if uid_outcome is not None else uid_legacy
+
 			merged[hotkey] = {
-				"uid": outcome.get("uid") or legacy.get("uid"),
+				"uid": uid,
 				"total_verified": verified,
 				"total_submissions": total_evaluated,
 				"total_failed": failed,

--- a/gas/cache/content_manager.py
+++ b/gas/cache/content_manager.py
@@ -644,11 +644,6 @@ class ContentManager:
 			outcome_stats = self.content_db.get_challenge_outcome_stats_last_n_hours(
 				lookback_hours=lookback_hours, limit=limit_val
 			)
-			if outcome_stats:
-				bt.logging.info(
-					f"Retrieved challenge-outcome stats for {len(outcome_stats)} miners"
-				)
-				return outcome_stats
 
 			verified_media = self.get_recent_verified_miner_media(
 				lookback_hours=lookback_hours, limit=limit_val
@@ -656,12 +651,20 @@ class ContentManager:
 			failed_media = self.get_recent_failed_miner_media(
 				lookback_hours=lookback_hours, limit=limit_val
 			)
-			if not verified_media and not failed_media:
+			if not verified_media and not failed_media and not outcome_stats:
 				bt.logging.debug(f"No verified or failed miner media in last {lookback_hours}h")
 				return {}
-			return self._build_verification_stats_from_verified_and_failed(
+			legacy_stats = self._build_verification_stats_from_verified_and_failed(
 				verified_media, failed_media
 			)
+
+			if outcome_stats:
+				bt.logging.info(
+					f"Retrieved challenge-outcome stats for {len(outcome_stats)} miners"
+				)
+				return self._merge_verification_stats(legacy_stats, outcome_stats)
+
+			return legacy_stats
 		except Exception as e:
 			bt.logging.error(f"Error getting verification stats for last {lookback_hours}h: {e}")
 			import traceback
@@ -725,6 +728,33 @@ class ContentManager:
 			}
 		bt.logging.info(f"Retrieved verification stats for {len(verification_stats)} miners")
 		return verification_stats
+
+	def _merge_verification_stats(
+		self,
+		legacy_stats: Dict[str, Dict[str, Any]],
+		outcome_stats: Dict[str, Dict[str, Any]],
+	) -> Dict[str, Dict[str, Any]]:
+		"""Merge legacy media-based stats with challenge-outcome stats.
+
+		For miners present in both sources, outcome data takes precedence,
+		supplemented by legacy verified_media_ids. Miners in only one source
+		pass through unchanged — no miner is dropped during transition.
+		"""
+		merged = {}
+		all_hotkeys = set(legacy_stats.keys()) | set(outcome_stats.keys())
+		for hotkey in all_hotkeys:
+			legacy = legacy_stats.get(hotkey, {})
+			outcome = outcome_stats.get(hotkey, {})
+			if outcome:
+				entry = dict(outcome)
+				if not entry.get("verified_media_ids"):
+					entry["verified_media_ids"] = legacy.get("verified_media_ids", [])
+				if "uid" not in entry:
+					entry["uid"] = legacy.get("uid")
+				merged[hotkey] = entry
+			else:
+				merged[hotkey] = dict(legacy)
+		return merged
 
 	def upload_batch_to_huggingface(
 		self, 

--- a/gas/cache/content_manager.py
+++ b/gas/cache/content_manager.py
@@ -736,24 +736,41 @@ class ContentManager:
 	) -> Dict[str, Dict[str, Any]]:
 		"""Merge legacy media-based stats with challenge-outcome stats.
 
-		For miners present in both sources, outcome data takes precedence,
-		supplemented by legacy media_ids. Miners in only one source
-		pass through unchanged — no miner is dropped during transition.
+		During the transition window (outcome data only covers challenges
+		sent after deployment), counts from both sources are summed so no
+		miner's totals drop. Miners in only one source pass through
+		unchanged — no miner is dropped.
 		"""
 		merged = {}
 		all_hotkeys = set(legacy_stats.keys()) | set(outcome_stats.keys())
 		for hotkey in all_hotkeys:
 			legacy = legacy_stats.get(hotkey, {})
 			outcome = outcome_stats.get(hotkey, {})
-			if outcome:
-				entry = dict(outcome)
-				if not entry.get("media_ids"):
-					entry["media_ids"] = legacy.get("media_ids", [])
-				if "uid" not in entry:
-					entry["uid"] = legacy.get("uid")
-				merged[hotkey] = entry
-			else:
-				merged[hotkey] = dict(legacy)
+
+			verified = legacy.get("total_verified", 0) + outcome.get("total_verified", 0)
+			failed = legacy.get("total_failed", 0) + outcome.get("total_failed", 0)
+			total_evaluated = verified + failed
+			pass_rate = (verified / total_evaluated) if total_evaluated > 0 else 0.0
+
+			legacy_ids = legacy.get("media_ids", [])
+			outcome_ids = outcome.get("media_ids", [])
+			all_ids = list(dict.fromkeys(legacy_ids + outcome_ids))
+
+			last_ts = max(
+				legacy.get("last_timestamp", 0) or 0,
+				outcome.get("last_timestamp", 0) or 0,
+			)
+
+			merged[hotkey] = {
+				"uid": outcome.get("uid") or legacy.get("uid"),
+				"total_verified": verified,
+				"total_submissions": total_evaluated,
+				"total_failed": failed,
+				"total_evaluated": total_evaluated,
+				"pass_rate": pass_rate,
+				"media_ids": all_ids,
+				"last_timestamp": last_ts,
+			}
 		return merged
 
 	def upload_batch_to_huggingface(

--- a/gas/cache/content_manager.py
+++ b/gas/cache/content_manager.py
@@ -736,10 +736,10 @@ class ContentManager:
 	) -> Dict[str, Dict[str, Any]]:
 		"""Merge legacy media-based stats with challenge-outcome stats.
 
-		During the transition window (outcome data only covers challenges
-		sent after deployment), counts from both sources are summed so no
-		miner's totals drop. Miners in only one source pass through
-		unchanged — no miner is dropped.
+		Post-deployment events appear in both sources. Use max() rather than
+		sum() to avoid double-counting: legacy always includes outcome's
+		events plus any pre-deployment media verified in the same window.
+		Miners in only one source pass through unchanged.
 		"""
 		merged = {}
 		all_hotkeys = set(legacy_stats.keys()) | set(outcome_stats.keys())
@@ -747,14 +747,23 @@ class ContentManager:
 			legacy = legacy_stats.get(hotkey, {})
 			outcome = outcome_stats.get(hotkey, {})
 
-			verified = legacy.get("total_verified", 0) + outcome.get("total_verified", 0)
-			failed = legacy.get("total_failed", 0) + outcome.get("total_failed", 0)
+			verified = max(
+				legacy.get("total_verified", 0),
+				outcome.get("total_verified", 0),
+			)
+			failed = max(
+				legacy.get("total_failed", 0),
+				outcome.get("total_failed", 0),
+			)
 			total_evaluated = verified + failed
 			pass_rate = (verified / total_evaluated) if total_evaluated > 0 else 0.0
 
 			legacy_ids = legacy.get("media_ids", [])
 			outcome_ids = outcome.get("media_ids", [])
-			all_ids = list(dict.fromkeys(legacy_ids + outcome_ids))
+			if len(outcome_ids) >= len(legacy_ids):
+				all_ids = outcome_ids
+			else:
+				all_ids = list(dict.fromkeys(legacy_ids + outcome_ids))
 
 			last_ts = max(
 				legacy.get("last_timestamp", 0) or 0,

--- a/gas/cache/content_manager.py
+++ b/gas/cache/content_manager.py
@@ -211,6 +211,12 @@ class ContentManager:
 				perceptual_hash=perceptual_hash,
 				c2pa_verified=c2pa_verified,
 				c2pa_issuer=c2pa_issuer,
+				task_id=task_id,
+			)
+			self.content_db.update_challenge_outcome(
+				task_id=task_id,
+				status="stored",
+				media_id=media_id,
 			)
 
 			bt.logging.info(f"Saved miner media to {save_path} with database ID: {media_id}")
@@ -529,6 +535,44 @@ class ContentManager:
 		"""Mark miner media as failed verification."""
 		return self.content_db.mark_miner_media_failed_verification(media_id)
 
+	def record_challenge_outcome(
+		self,
+		task_id: str,
+		uid: int,
+		hotkey: str,
+		prompt_id: str,
+		modality: str,
+		status: str = "pending",
+		failure_reason: Optional[str] = None,
+		media_id: Optional[str] = None,
+		created_at: Optional[float] = None,
+	) -> bool:
+		return self.content_db.record_challenge_outcome(
+			task_id=task_id,
+			uid=uid,
+			hotkey=hotkey,
+			prompt_id=prompt_id,
+			modality=modality,
+			status=status,
+			failure_reason=failure_reason,
+			media_id=media_id,
+			created_at=created_at,
+		)
+
+	def update_challenge_outcome(
+		self,
+		task_id: str,
+		status: str,
+		failure_reason: Optional[str] = None,
+		media_id: Optional[str] = None,
+	) -> bool:
+		return self.content_db.update_challenge_outcome(
+			task_id=task_id,
+			status=status,
+			failure_reason=failure_reason,
+			media_id=media_id,
+		)
+
 	def store_clip_embedding(self, media_id: str, embedding_blob: bytes) -> bool:
 		"""Store a CLIP embedding for a media entry (deep-feature duplicate detection)."""
 		return self.content_db.update_media_embedding(media_id, embedding_blob)
@@ -597,6 +641,15 @@ class ContentManager:
 		"""
 		try:
 			limit_val = limit or 1000
+			outcome_stats = self.content_db.get_challenge_outcome_stats_last_n_hours(
+				lookback_hours=lookback_hours, limit=limit_val
+			)
+			if outcome_stats:
+				bt.logging.info(
+					f"Retrieved challenge-outcome stats for {len(outcome_stats)} miners"
+				)
+				return outcome_stats
+
 			verified_media = self.get_recent_verified_miner_media(
 				lookback_hours=lookback_hours, limit=limit_val
 			)

--- a/gas/cache/content_manager.py
+++ b/gas/cache/content_manager.py
@@ -737,7 +737,7 @@ class ContentManager:
 		"""Merge legacy media-based stats with challenge-outcome stats.
 
 		For miners present in both sources, outcome data takes precedence,
-		supplemented by legacy verified_media_ids. Miners in only one source
+		supplemented by legacy media_ids. Miners in only one source
 		pass through unchanged — no miner is dropped during transition.
 		"""
 		merged = {}
@@ -747,8 +747,8 @@ class ContentManager:
 			outcome = outcome_stats.get(hotkey, {})
 			if outcome:
 				entry = dict(outcome)
-				if not entry.get("verified_media_ids"):
-					entry["verified_media_ids"] = legacy.get("verified_media_ids", [])
+				if not entry.get("media_ids"):
+					entry["media_ids"] = legacy.get("media_ids", [])
 				if "uid" not in entry:
 					entry["uid"] = legacy.get("uid")
 				merged[hotkey] = entry

--- a/gas/cache/types.py
+++ b/gas/cache/types.py
@@ -87,6 +87,9 @@ class MediaEntry:
     c2pa_verified: Optional[bool] = False  # C2PA validation passed
     c2pa_issuer: Optional[str] = None  # Issuer name if C2PA verified
 
+    # Miner challenge tracking
+    task_id: Optional[str] = None
+
     # Common fields
     created_at: float = None
     resolution: Optional[tuple[int, int]] = None  # (width, height)
@@ -123,3 +126,26 @@ class VerificationResult:
         self.generated_caption = generated_caption
         self.verification_score = verification_score
         self.passed = passed
+
+
+@dataclass
+class ChallengeOutcome:
+    """Represents a generation-miner challenge outcome for reward accounting."""
+
+    task_id: str
+    uid: int
+    hotkey: str
+    prompt_id: str
+    modality: str
+    status: str
+    failure_reason: Optional[str] = None
+    media_id: Optional[str] = None
+    created_at: float = None
+    updated_at: float = None
+
+    def __post_init__(self):
+        now = time.time()
+        if self.created_at is None:
+            self.created_at = now
+        if self.updated_at is None:
+            self.updated_at = self.created_at

--- a/gas/evaluation/generative_challenge_manager.py
+++ b/gas/evaluation/generative_challenge_manager.py
@@ -140,9 +140,11 @@ class GenerativeChallengeManager:
 
         if response_data and response_data.get("task_id"):
             miner_task_id = response_data.get("task_id")
+            miner_hotkey = self.metagraph.hotkeys[uid]
             with self.challenge_lock:
                 self.challenge_tasks[miner_task_id] = {
                     "uid": uid,
+                    "hotkey": miner_hotkey,
                     "prompt_id": prompt_entry.id,
                     "prompt_content": prompt_entry.content,
                     "modality": modality,
@@ -150,6 +152,14 @@ class GenerativeChallengeManager:
                     "status": "pending",
                     "sent_at": time.time(),
                 }
+            self.content_manager.record_challenge_outcome(
+                task_id=miner_task_id,
+                uid=uid,
+                hotkey=miner_hotkey,
+                prompt_id=prompt_entry.id,
+                modality=modality.value,
+                status="pending",
+            )
             bt.logging.info(
                 f"Stored challenge task {miner_task_id} for UID {uid}. Total active tasks: {len(self.challenge_tasks)}"
             )
@@ -223,10 +233,16 @@ class GenerativeChallengeManager:
                     )
                     return Response(status_code=200, content="Task not found in current session")
                 generator_uid = self.challenge_tasks[task_id].get("uid")
+                generator_hotkey = self.challenge_tasks[task_id].get("hotkey") or self.metagraph.hotkeys[generator_uid]
                 del self.challenge_tasks[task_id]
+            self.content_manager.update_challenge_outcome(
+                task_id=task_id,
+                status="failed",
+                failure_reason=f"miner_reported_failure: {err_msg}",
+            )
             bt.logging.warning(
                 f"Generative task failed (miner-reported): task_id={task_id} uid={generator_uid} "
-                f"error={err_msg!r} (IP: {client_ip})"
+                f"hotkey={generator_hotkey[:16]}... error={err_msg!r} (IP: {client_ip})"
             )
             return Response(status_code=200, content="Failure recorded")
 
@@ -296,6 +312,11 @@ class GenerativeChallengeManager:
             else:
                 self.challenge_tasks[task_id]["status"] = "failed"
                 self.challenge_tasks[task_id]["error_message"] = error_message or "Failed to store binary content"
+                self.content_manager.update_challenge_outcome(
+                    task_id=task_id,
+                    status="failed",
+                    failure_reason=error_message or "Failed to store binary content",
+                )
 
                 del self.challenge_tasks[task_id]
                 return Response(status_code=400, content=error_message or "Failed to store binary content")
@@ -610,6 +631,11 @@ class GenerativeChallengeManager:
                         stale_tasks.append(task_id)
 
                 for task_id in stale_tasks:
+                    self.content_manager.update_challenge_outcome(
+                        task_id=task_id,
+                        status="failed",
+                        failure_reason="challenge_timeout",
+                    )
                     del self.challenge_tasks[task_id]
                     bt.logging.debug(f"Removed stale task {task_id} during state save")
 

--- a/gas/evaluation/generative_challenge_manager.py
+++ b/gas/evaluation/generative_challenge_manager.py
@@ -309,17 +309,17 @@ class GenerativeChallengeManager:
 
                 del self.challenge_tasks[task_id]
                 return Response(status_code=200, content="Binary content received")
-            else:
-                self.challenge_tasks[task_id]["status"] = "failed"
-                self.challenge_tasks[task_id]["error_message"] = error_message or "Failed to store binary content"
-                self.content_manager.update_challenge_outcome(
-                    task_id=task_id,
-                    status="failed",
-                    failure_reason=error_message or "Failed to store binary content",
-                )
 
-                del self.challenge_tasks[task_id]
-                return Response(status_code=400, content=error_message or "Failed to store binary content")
+            # Storage failed — release lock before DB call
+            failure_reason = error_message or "Failed to store binary content"
+            del self.challenge_tasks[task_id]
+
+        self.content_manager.update_challenge_outcome(
+            task_id=task_id,
+            status="failed",
+            failure_reason=failure_reason,
+        )
+        return Response(status_code=400, content=failure_reason)
 
     async def store_binary_content(
         self, binary_data: bytes, content_type: str, generator_uid: int, task_id: str
@@ -631,15 +631,18 @@ class GenerativeChallengeManager:
                         stale_tasks.append(task_id)
 
                 for task_id in stale_tasks:
-                    self.content_manager.update_challenge_outcome(
-                        task_id=task_id,
-                        status="failed",
-                        failure_reason="challenge_timeout",
-                    )
                     del self.challenge_tasks[task_id]
                     bt.logging.debug(f"Removed stale task {task_id} during state save")
 
                 tasks_to_save = self.challenge_tasks.copy()
+
+            # Release lock before making blocking DB calls
+            for task_id in stale_tasks:
+                self.content_manager.update_challenge_outcome(
+                    task_id=task_id,
+                    status="failed",
+                    failure_reason="challenge_timeout",
+                )
 
             filepath = os.path.join(save_dir, filename)
             with open(filepath, 'wb') as f:

--- a/tests/test_challenge_outcomes.py
+++ b/tests/test_challenge_outcomes.py
@@ -1,0 +1,55 @@
+import tempfile
+import unittest
+from pathlib import Path
+
+from gas.cache.content_db import ContentDB
+from gas.types import MediaType, Modality, SourceType
+
+
+class ChallengeOutcomeStatsTest(unittest.TestCase):
+    def test_challenge_outcomes_count_pre_storage_failures(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            db = ContentDB(Path(tmpdir) / "prompts.db")
+            prompt_id = db.add_prompt_entry("a test prompt", modality="image")
+            media_id = db.add_media_entry(
+                prompt_id=prompt_id,
+                file_path=str(Path(tmpdir) / "media.png"),
+                modality=Modality.IMAGE,
+                media_type=MediaType.SYNTHETIC,
+                source_type=SourceType.MINER,
+                uid=1,
+                hotkey="hotkey-1",
+                verified=True,
+                task_id="task-verified",
+            )
+
+            db.record_challenge_outcome(
+                task_id="task-verified",
+                uid=1,
+                hotkey="hotkey-1",
+                prompt_id=prompt_id,
+                modality="image",
+                status="verified",
+                media_id=media_id,
+            )
+            db.record_challenge_outcome(
+                task_id="task-rejected",
+                uid=1,
+                hotkey="hotkey-1",
+                prompt_id=prompt_id,
+                modality="image",
+                status="failed",
+                failure_reason="C2PA verification failed",
+            )
+
+            stats = db.get_challenge_outcome_stats_last_n_hours(lookback_hours=1)
+
+            self.assertEqual(stats["hotkey-1"]["total_verified"], 1)
+            self.assertEqual(stats["hotkey-1"]["total_failed"], 1)
+            self.assertEqual(stats["hotkey-1"]["total_evaluated"], 2)
+            self.assertEqual(stats["hotkey-1"]["pass_rate"], 0.5)
+            self.assertEqual(stats["hotkey-1"]["media_ids"], [media_id])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Add generator challenge outcome tracking so pre-storage rejects, miner failures, timeouts, and CLIP outcomes share one reward-accounting record.
- Link miner media rows back to task IDs and update challenge outcomes when verification marks media as passed or failed.
- Add a regression test covering pass-rate denominator behavior with pre-storage failures.

## Test plan
- python -m py_compile gas/cache/__init__.py gas/cache/types.py gas/cache/content_db.py gas/cache/content_manager.py gas/evaluation/generative_challenge_manager.py tests/test_challenge_outcomes.py
- python -m unittest tests.test_challenge_outcomes
- git diff --check


Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new SQLite schema and write-path updates to track and aggregate generator challenge outcomes, which can affect reward/pass-rate calculations and requires correct DB migrations. Risk is moderated by isolated changes and a new regression test covering pre-storage failure accounting.
> 
> **Overview**
> Adds persistent tracking of generator challenge outcomes so **pre-storage rejects, miner-reported failures/timeouts, and post-storage verification** are all counted in a single reward-accounting record.
> 
> Introduces `generator_challenge_outcomes` in `ContentDB` plus a `media.task_id` linkage, and wires the challenge lifecycle to update outcome status on send (`pending`), store (`stored`), verification (`verified`/`failed`), miner failure callbacks, and timeouts; `ContentManager.get_verification_stats_last_n_hours()` now merges legacy media-derived stats with outcome-derived stats to include pre-storage failures.
> 
> Also switches `gas/cache/__init__.py` to lazy imports via `__getattr__`, adds a `ChallengeOutcome` type, and includes `tests/test_challenge_outcomes.py` to ensure pass-rate denominators include pre-storage failures.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 66858a477371a905774b7de4a312a288f8c0f4f3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->