### PR TITLE
Add global generator dedup checks

### DIFF
--- a/gas/config.py
+++ b/gas/config.py
@@ -451,6 +451,13 @@ def add_validator_args(parser):
         default=0.96,
     )
 
+    parser.add_argument(
+        "--verification.global-dup-hamming-threshold",
+        type=int,
+        help="Hamming distance threshold for global (cross-prompt) perceptual hash duplicate detection (default: 4)",
+        default=4,
+    )
+
 
 def add_generation_service_args(parser):
     """Add generation service specific arguments to the parser."""

--- a/gas/evaluation/generative_challenge_manager.py
+++ b/gas/evaluation/generative_challenge_manager.py
@@ -35,8 +35,6 @@ from gas.verification.duplicate_detection import (
     DEFAULT_TEMPORAL_TAMPER_RATIO,
 )
 
-GLOBAL_DUPLICATE_HAMMING_THRESHOLD = 4
-
 
 class GenerativeChallengeManager:
     def __init__(
@@ -390,7 +388,7 @@ class GenerativeChallengeManager:
 
                     global_duplicate_info = self.content_manager.check_duplicate(
                         perceptual_hash,
-                        threshold=GLOBAL_DUPLICATE_HAMMING_THRESHOLD,
+                        threshold=getattr(getattr(self.config, 'verification', None), 'global_dup_hamming_threshold', 4),
                         prompt_id=None,
                     )
                     if global_duplicate_info:

--- a/gas/evaluation/generative_challenge_manager.py
+++ b/gas/evaluation/generative_challenge_manager.py
@@ -35,6 +35,8 @@ from gas.verification.duplicate_detection import (
     DEFAULT_TEMPORAL_TAMPER_RATIO,
 )
 
+GLOBAL_DUPLICATE_HAMMING_THRESHOLD = 4
+
 
 class GenerativeChallengeManager:
     def __init__(
@@ -368,7 +370,7 @@ class GenerativeChallengeManager:
                 except Exception as e:
                     bt.logging.debug(f"Temporal tampering check skipped: {e}")
 
-            # Step 2: Compute perceptual hash and check for duplicates within same prompt
+            # Step 2: Compute perceptual hash and check prompt/global duplicates
             perceptual_hash = None
             try:
                 perceptual_hash = compute_media_hash(binary_data, modality=modality_str)
@@ -385,6 +387,19 @@ class GenerativeChallengeManager:
                             f"matches media {dup_media_id} with distance {dup_distance}"
                         )
                         return None, "Duplicate content detected"
+
+                    global_duplicate_info = self.content_manager.check_duplicate(
+                        perceptual_hash,
+                        threshold=GLOBAL_DUPLICATE_HAMMING_THRESHOLD,
+                        prompt_id=None,
+                    )
+                    if global_duplicate_info:
+                        dup_media_id, dup_distance = global_duplicate_info
+                        bt.logging.warning(
+                            f"REJECTED global duplicate from UID {generator_uid} task {task_id}: "
+                            f"matches media {dup_media_id} with distance {dup_distance}"
+                        )
+                        return None, "Global duplicate content detected"
             except Exception as e:
                 bt.logging.debug(f"Duplicate detection skipped: {e}")
 

--- a/gas/verification/verification_pipeline.py
+++ b/gas/verification/verification_pipeline.py
@@ -3,6 +3,7 @@ from statistics import mean, median
 from typing import List, Dict, Any, Optional, Tuple
 
 import bittensor as bt
+import numpy as np
 import torch
 
 from gas.cache.content_manager import ContentManager
@@ -11,6 +12,7 @@ from .clip_utils import (
     calculate_clip_alignment_consensus,
     preload_clip_models,
     find_near_duplicate_by_embedding,
+    DEFAULT_EMBEDDING_SIMILARITY_THRESHOLD,
     serialize_features,
 )
 
@@ -284,12 +286,37 @@ def verify_media(
                 exclude_ids=current_batch_ids, limit=5000,
             )
 
+            accepted_batch_embeddings = []
             for result in verification_results:
                 if not result.passed:
                     continue
                 entry = result.media_entry
                 features = entry_to_features.get(entry.id)
                 if features is None:
+                    continue
+
+                query = features.astype(np.float32)
+                query_norm = query / (np.linalg.norm(query) + 1e-8)
+                current_batch_dup = None
+                for prior_entry_id, prior_features in accepted_batch_embeddings:
+                    prior = prior_features.astype(np.float32)
+                    prior_norm = prior / (np.linalg.norm(prior) + 1e-8)
+                    sim = float(np.dot(query_norm, prior_norm))
+                    if sim > DEFAULT_EMBEDDING_SIMILARITY_THRESHOLD:
+                        current_batch_dup = (prior_entry_id, sim)
+                        break
+
+                if current_batch_dup is not None:
+                    dup_id, sim = current_batch_dup
+                    bt.logging.warning(
+                        f"REJECTED near-duplicate in current batch: media_id={entry.id} "
+                        f"matches {dup_id} with cosine_sim={sim:.4f}"
+                    )
+                    result.passed = False
+                    if result.verification_score:
+                        result.verification_score["embedding_duplicate"] = True
+                        result.verification_score["embedding_duplicate_of"] = dup_id
+                        result.verification_score["embedding_duplicate_scope"] = "current_batch"
                     continue
 
                 near_dup = find_near_duplicate_by_embedding(features, stored_embeddings)
@@ -303,6 +330,10 @@ def verify_media(
                     if result.verification_score:
                         result.verification_score["embedding_duplicate"] = True
                         result.verification_score["embedding_duplicate_of"] = dup_id
+                        result.verification_score["embedding_duplicate_scope"] = "stored"
+                    continue
+
+                accepted_batch_embeddings.append((entry.id, features))
 
                 # Store embedding for future duplicate checks
                 try:


### PR DESCRIPTION
## Summary
- Add a stricter global perceptual-hash duplicate gate before miner media storage, in addition to the existing prompt-scoped check.
- Detect near-duplicate embeddings within the current verification batch before comparing against stored embeddings.
- Annotate embedding duplicate failures with whether they matched current-batch or stored media.

## Test plan
- python -m py_compile gas/evaluation/generative_challenge_manager.py gas/verification/verification_pipeline.py
- git diff --check


Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Tightens duplicate rejection logic for generator media and verification batches, which can increase false rejections and affect stored/rewarded content. Changes are localized but impact core scoring/storage behavior.
> 
> **Overview**
> Adds a new validator config flag `--verification.global-dup-hamming-threshold` and applies a **second, cross-prompt perceptual-hash duplicate check** before accepting generator uploads, rejecting matches against any previously stored media.
> 
> Enhances CLIP verification duplicate handling by **detecting near-duplicate embeddings within the current verification batch** (before checking against stored embeddings) and annotating embedding-duplicate failures with whether the match was *current-batch* or *stored*.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1b96ebb0cad3f9775ad636cf648979f3646fe3d8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->