### PR TITLE
Reject failed pre-storage checks

### DIFF
--- a/gas/evaluation/generative_challenge_manager.py
+++ b/gas/evaluation/generative_challenge_manager.py
@@ -355,8 +355,8 @@ class GenerativeChallengeManager:
                 tmp_path = None
                 try:
                     with tempfile.NamedTemporaryFile(suffix=".mp4", delete=False) as tmp:
-                        tmp.write(binary_data)
                         tmp_path = tmp.name
+                        tmp.write(binary_data)
                     is_tampered, ratio, jumps, total = detect_temporal_tampering(
                         tmp_path,
                         jump_threshold=DEFAULT_TEMPORAL_PHASH_JUMP_THRESHOLD,

--- a/gas/evaluation/generative_challenge_manager.py
+++ b/gas/evaluation/generative_challenge_manager.py
@@ -344,10 +344,15 @@ class GenerativeChallengeManager:
                     )
                     return None, "Corrupted or unreadable media"
             except Exception as e:
-                bt.logging.debug(f"Corruption check error (allowing): {e}")
+                bt.logging.warning(
+                    f"REJECTED media from UID {generator_uid} task {task_id}: "
+                    f"corruption check error: {e}"
+                )
+                return None, f"Corruption check error: {e}"
 
             # Step 1b: Check for temporal tampering in videos (frame shuffling/splicing/speed-up)
             if modality_str == "video":
+                tmp_path = None
                 try:
                     with tempfile.NamedTemporaryFile(suffix=".mp4", delete=False) as tmp:
                         tmp.write(binary_data)
@@ -357,7 +362,6 @@ class GenerativeChallengeManager:
                         jump_threshold=DEFAULT_TEMPORAL_PHASH_JUMP_THRESHOLD,
                         tamper_ratio=DEFAULT_TEMPORAL_TAMPER_RATIO,
                     )
-                    os.unlink(tmp_path)
                     if is_tampered:
                         bt.logging.warning(
                             f"REJECTED temporally tampered video from UID {generator_uid} "
@@ -366,7 +370,14 @@ class GenerativeChallengeManager:
                         )
                         return None, "Temporally tampered video detected"
                 except Exception as e:
-                    bt.logging.debug(f"Temporal tampering check skipped: {e}")
+                    bt.logging.warning(
+                        f"REJECTED video from UID {generator_uid} task {task_id}: "
+                        f"temporal tampering check error: {e}"
+                    )
+                    return None, f"Temporal tampering check error: {e}"
+                finally:
+                    if tmp_path:
+                        Path(tmp_path).unlink(missing_ok=True)
 
             # Step 2: Compute perceptual hash and check for duplicates within same prompt
             perceptual_hash = None
@@ -386,7 +397,11 @@ class GenerativeChallengeManager:
                         )
                         return None, "Duplicate content detected"
             except Exception as e:
-                bt.logging.debug(f"Duplicate detection skipped: {e}")
+                bt.logging.warning(
+                    f"REJECTED media from UID {generator_uid} task {task_id}: "
+                    f"duplicate detection error: {e}"
+                )
+                return None, f"Duplicate detection error: {e}"
 
             # Step 3: Verify C2PA content credentials - REQUIRE trusted issuer
             c2pa_verified = False


### PR DESCRIPTION
## Summary
- Reject media when corruption, temporal tamper, or duplicate checks raise errors instead of allowing validation to continue.
- Ensure temporary video files used for temporal tamper checks are cleaned up in a finally block.

## Test plan
- python -m py_compile gas/evaluation/generative_challenge_manager.py
- git diff --check


Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes validation behavior to fail closed: miners’ media will now be rejected when corruption/temporal-tamper/duplicate checks error, which could increase false rejections if checks are flaky. Also touches temp-file handling in the video path, but is localized to pre-storage validation.
> 
> **Overview**
> Tightens pre-storage validation in `GenerativeChallengeManager.store_binary_content` by **rejecting uploads when corruption detection, video temporal-tamper detection, or duplicate detection raise exceptions** (previously these errors were logged and validation continued).
> 
> For video tamper checks, it now **guarantees temp `.mp4` cleanup in a `finally` block** and improves rejection logging/messages to include the specific check failure.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 84cb982f86135f0688d12e86080695b4c4ce633c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->