### PR TITLE
Log verification abuse summaries

### DIFF
--- a/gas/verification/verification_pipeline.py
+++ b/gas/verification/verification_pipeline.py
@@ -201,11 +201,13 @@ def verify_media(
                     f"Corrupted/invalid video detected: {media_entry.file_path} (ID: {media_entry.id})"
                 )
                 corrupted_videos.append(media_entry)
-                # Still create a failed result for this entry
                 result = VerificationResult(
                     media_entry=media_entry,
                     original_prompt=prompt,
-                    verification_score=None,
+                    verification_score={
+                        "consensus_details": consensus_result,
+                        "corrupted": True,
+                    },
                     passed=False,
                 )
                 verification_results.append(result)
@@ -364,7 +366,7 @@ def _log_breakdowns(results: List[VerificationResult], threshold: float) -> None
         score = r.verification_score or {}
         if isinstance(score, dict):
             details = score.get("consensus_details") or {}
-            if details.get("corrupted"):
+            if details.get("corrupted") or score.get("corrupted"):
                 corrupted_count += 1
             if score.get("embedding_duplicate"):
                 embedding_duplicate_count += 1

--- a/gas/verification/verification_pipeline.py
+++ b/gas/verification/verification_pipeline.py
@@ -59,9 +59,7 @@ def run_verification(
 
     bt.logging.info("Verification batch complete, updating database")
     for result in results:
-        vs = result.verification_score or {}
-        is_corrupted = isinstance(vs, dict) and vs.get("corrupted", False)
-        if result.verification_score and not is_corrupted:
+        if result.verification_score and not _is_corrupted(result):
             try:
                 if result.passed:
                     content_manager.mark_miner_media_verified(result.media_entry.id)
@@ -73,14 +71,12 @@ def run_verification(
                 bt.logging.error(f"Error marking media verification status: {e}")
 
     successful_verifications = sum(
-        1 for r in results if r.verification_score is not None
-        and not (isinstance(r.verification_score, dict) and r.verification_score.get("corrupted"))
+        1 for r in results if r.verification_score is not None and not _is_corrupted(r)
     )
     passed_verifications = sum(1 for r in results if r.passed)
     failed_verifications = sum(
         1 for r in results
-        if r.verification_score is not None and not r.passed
-        and not (isinstance(r.verification_score, dict) and r.verification_score.get("corrupted"))
+        if r.verification_score is not None and not r.passed and not _is_corrupted(r)
     )
 
     bt.logging.info(
@@ -335,12 +331,16 @@ def verify_media(
         ]
 
 
+def _is_corrupted(result: VerificationResult) -> bool:
+    vs = result.verification_score
+    return isinstance(vs, dict) and bool(vs.get("corrupted", False))
+
+
 def _bucket_stats(results: List[VerificationResult], threshold: float) -> Dict[str, Any]:
     """Aggregate count / pass-rate / score-stats for a slice of results."""
     scored = [
         r for r in results
-        if r.verification_score
-        and not (isinstance(r.verification_score, dict) and r.verification_score.get("corrupted"))
+        if r.verification_score and not _is_corrupted(r)
     ]
     scores = [r.verification_score["score"] for r in scored]
     n = len(results)
@@ -379,8 +379,7 @@ def _log_breakdowns(results: List[VerificationResult], threshold: float) -> None
     for r in results:
         score = r.verification_score or {}
         if isinstance(score, dict):
-            details = score.get("consensus_details") or {}
-            if details.get("corrupted") or score.get("corrupted"):
+            if _is_corrupted(r):
                 corrupted_count += 1
             if score.get("embedding_duplicate"):
                 embedding_duplicate_count += 1
@@ -458,20 +457,14 @@ def get_verification_summary(results: List[VerificationResult]) -> Dict[str, Any
         }
 
     total = len(results)
-    corrupted = sum(
-        1 for r in results
-        if isinstance(r.verification_score, dict) and r.verification_score.get("corrupted")
-    )
+    corrupted = sum(1 for r in results if _is_corrupted(r))
     successful = sum(
-        1 for r in results
-        if r.verification_score is not None
-        and not (isinstance(r.verification_score, dict) and r.verification_score.get("corrupted"))
+        1 for r in results if r.verification_score is not None and not _is_corrupted(r)
     )
     passed = sum(1 for r in results if r.passed)
     failed = sum(
         1 for r in results
-        if r.verification_score is not None and not r.passed
-        and not (isinstance(r.verification_score, dict) and r.verification_score.get("corrupted"))
+        if r.verification_score is not None and not r.passed and not _is_corrupted(r)
     )
     errors = sum(1 for r in results if r.verification_score is None) + corrupted
 
@@ -482,8 +475,7 @@ def get_verification_summary(results: List[VerificationResult]) -> Dict[str, Any
             else r.verification_score
         )
         for r in results
-        if r.verification_score is not None
-        and not (isinstance(r.verification_score, dict) and r.verification_score.get("corrupted"))
+        if r.verification_score is not None and not _is_corrupted(r)
     ]
     avg_score = sum(scores) / len(scores) if scores else 0.0
 

--- a/gas/verification/verification_pipeline.py
+++ b/gas/verification/verification_pipeline.py
@@ -59,7 +59,9 @@ def run_verification(
 
     bt.logging.info("Verification batch complete, updating database")
     for result in results:
-        if result.verification_score:  # Only process if verification actually ran
+        vs = result.verification_score or {}
+        is_corrupted = isinstance(vs, dict) and vs.get("corrupted", False)
+        if result.verification_score and not is_corrupted:
             try:
                 if result.passed:
                     content_manager.mark_miner_media_verified(result.media_entry.id)
@@ -72,6 +74,7 @@ def run_verification(
 
     successful_verifications = sum(
         1 for r in results if r.verification_score is not None
+        and not (isinstance(r.verification_score, dict) and r.verification_score.get("corrupted"))
     )
     passed_verifications = sum(1 for r in results if r.passed)
     failed_verifications = sum(1 for r in results if r.verification_score is not None and not r.passed)

--- a/gas/verification/verification_pipeline.py
+++ b/gas/verification/verification_pipeline.py
@@ -77,7 +77,11 @@ def run_verification(
         and not (isinstance(r.verification_score, dict) and r.verification_score.get("corrupted"))
     )
     passed_verifications = sum(1 for r in results if r.passed)
-    failed_verifications = sum(1 for r in results if r.verification_score is not None and not r.passed)
+    failed_verifications = sum(
+        1 for r in results
+        if r.verification_score is not None and not r.passed
+        and not (isinstance(r.verification_score, dict) and r.verification_score.get("corrupted"))
+    )
 
     bt.logging.info(
         f"Verification batch complete: {successful_verifications}/{len(results)} processed, "
@@ -333,7 +337,11 @@ def verify_media(
 
 def _bucket_stats(results: List[VerificationResult], threshold: float) -> Dict[str, Any]:
     """Aggregate count / pass-rate / score-stats for a slice of results."""
-    scored = [r for r in results if r.verification_score]
+    scored = [
+        r for r in results
+        if r.verification_score
+        and not (isinstance(r.verification_score, dict) and r.verification_score.get("corrupted"))
+    ]
     scores = [r.verification_score["score"] for r in scored]
     n = len(results)
     n_scored = len(scored)
@@ -450,10 +458,22 @@ def get_verification_summary(results: List[VerificationResult]) -> Dict[str, Any
         }
 
     total = len(results)
-    successful = sum(1 for r in results if r.verification_score is not None)
+    corrupted = sum(
+        1 for r in results
+        if isinstance(r.verification_score, dict) and r.verification_score.get("corrupted")
+    )
+    successful = sum(
+        1 for r in results
+        if r.verification_score is not None
+        and not (isinstance(r.verification_score, dict) and r.verification_score.get("corrupted"))
+    )
     passed = sum(1 for r in results if r.passed)
-    failed = sum(1 for r in results if r.verification_score is not None and not r.passed)
-    errors = sum(1 for r in results if r.verification_score is None)
+    failed = sum(
+        1 for r in results
+        if r.verification_score is not None and not r.passed
+        and not (isinstance(r.verification_score, dict) and r.verification_score.get("corrupted"))
+    )
+    errors = sum(1 for r in results if r.verification_score is None) + corrupted
 
     scores = [
         (
@@ -463,6 +483,7 @@ def get_verification_summary(results: List[VerificationResult]) -> Dict[str, Any
         )
         for r in results
         if r.verification_score is not None
+        and not (isinstance(r.verification_score, dict) and r.verification_score.get("corrupted"))
     ]
     avg_score = sum(scores) / len(scores) if scores else 0.0
 

--- a/gas/verification/verification_pipeline.py
+++ b/gas/verification/verification_pipeline.py
@@ -357,6 +357,33 @@ def _log_breakdowns(results: List[VerificationResult], threshold: float) -> None
         f"threshold={threshold:.3f}"
     )
 
+    corrupted_count = 0
+    embedding_duplicate_count = 0
+    embedding_duplicate_by_miner: Dict[Tuple[Any, str], int] = defaultdict(int)
+    for r in results:
+        score = r.verification_score or {}
+        if isinstance(score, dict):
+            details = score.get("consensus_details") or {}
+            if details.get("corrupted"):
+                corrupted_count += 1
+            if score.get("embedding_duplicate"):
+                embedding_duplicate_count += 1
+                m = r.media_entry
+                embedding_duplicate_by_miner[(m.uid, (m.hotkey or "")[:8])] += 1
+
+    if corrupted_count or embedding_duplicate_count:
+        bt.logging.warning(
+            f"[VERIFY-ABUSE-SUMMARY] corrupted={corrupted_count} "
+            f"embedding_duplicates={embedding_duplicate_count}"
+        )
+        for key, count in sorted(
+            embedding_duplicate_by_miner.items(),
+            key=lambda kv: -kv[1],
+        ):
+            bt.logging.warning(
+                f"[VERIFY-ABUSE-BY-MINER] key={key!r} embedding_duplicates={count}"
+            )
+
     def _log_group(label: str, groups: Dict[Any, List[VerificationResult]]) -> None:
         # Sort by sample count descending so the most active buckets surface first.
         ordered = sorted(groups.items(), key=lambda kv: -len(kv[1]))

--- a/gas/verification/verification_pipeline.py
+++ b/gas/verification/verification_pipeline.py
@@ -205,8 +205,11 @@ def verify_media(
                     media_entry=media_entry,
                     original_prompt=prompt,
                     verification_score={
+                        "score": 0.0,
                         "consensus_details": consensus_result,
                         "corrupted": True,
+                        "passed": False,
+                        "threshold": threshold,
                     },
                     passed=False,
                 )


### PR DESCRIPTION
## Summary
- Add aggregate verification warning logs for corrupted media and embedding duplicate rejections.
- Break out embedding duplicate counts by miner to make repeated abuse patterns easier to spot from validator logs.

## Test plan
- python -m py_compile gas/verification/verification_pipeline.py
- git diff --check


Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how corrupted media is represented and counted (now treated as an error-like case and excluded from DB updates/statistics), which could affect validator metrics and downstream consumers of `verification_score`. Adds additional warning logs for abuse patterns but does not change core scoring logic.
> 
> **Overview**
> Corrupted/unreadable media is now explicitly flagged via `verification_score["corrupted"]=True` and is **excluded** from normal verification processing: DB status updates, scored/pass/fail aggregates, and summary statistics.
> 
> Adds new warning-level *abuse summaries* in `_log_breakdowns` that report total corrupted items and embedding-duplicate rejections, including a per-miner breakdown to help spot repeated duplicate submissions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0ee7158a2cebd2a325e06519c26f823072a14d4b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->