### PR TITLE
feat: prompt diversity engine — sampled registers, committed shot specs, QC + remix

### DIFF
--- a/gas/cache/content_manager.py
+++ b/gas/cache/content_manager.py
@@ -79,7 +79,8 @@ class ContentManager:
 		event_count: Optional[int] = None,
 		scene_json: Optional[str] = None,
 		spec_json: Optional[str] = None,
-	) -> str:
+	) -> Optional[str]:
+		"""Write a prompt; returns its id, or None if rejected as a near-duplicate."""
 		try:
 			prompt_id = self.prompts.add_prompt_entry(
 				content=content,

--- a/gas/cache/content_manager.py
+++ b/gas/cache/content_manager.py
@@ -74,12 +74,22 @@ class ContentManager:
 		content: str,
 		source_media_id: Optional[str] = None,
 		modality: Optional[str] = None,
+		register: Optional[str] = None,
+		length_band: Optional[str] = None,
+		event_count: Optional[int] = None,
+		scene_json: Optional[str] = None,
+		spec_json: Optional[str] = None,
 	) -> str:
 		try:
 			prompt_id = self.prompts.add_prompt_entry(
 				content=content,
 				source_media_id=source_media_id,
 				modality=modality,
+				register=register,
+				length_band=length_band,
+				event_count=event_count,
+				scene_json=scene_json,
+				spec_json=spec_json,
 			)
 			bt.logging.debug(f"Added prompt (modality={modality}) to database with ID: {prompt_id}")
 			return prompt_id

--- a/gas/cache/db/migrations.py
+++ b/gas/cache/db/migrations.py
@@ -60,6 +60,17 @@ MIGRATIONS = [
             "ALTER TABLE media ADD COLUMN clip_embedding BLOB",
         ],
     ),
+    (
+        "add_prompt_spec_columns",
+        [
+            "ALTER TABLE prompts ADD COLUMN register TEXT",
+            "ALTER TABLE prompts ADD COLUMN length_band TEXT",
+            "ALTER TABLE prompts ADD COLUMN event_count INTEGER",
+            "ALTER TABLE prompts ADD COLUMN scene_json TEXT",
+            "ALTER TABLE prompts ADD COLUMN spec_json TEXT",
+            "CREATE INDEX IF NOT EXISTS idx_prompts_register ON prompts (register)",
+        ],
+    ),
 ]
 
 

--- a/gas/cache/db/prompt_store.py
+++ b/gas/cache/db/prompt_store.py
@@ -1,5 +1,6 @@
 """PromptStore — CRUD and sampling for the prompts table."""
 
+import re
 import time
 import uuid
 from typing import List, Dict, Optional, Tuple, Any
@@ -13,8 +14,47 @@ from gas.cache.db.connection import ConnectionManager
 class PromptStore:
     """Data access for the ``prompts`` table."""
 
+    # Near-duplicate guard: a new prompt is rejected when its 5-gram Jaccard
+    # similarity against any of the most recent prompts in the same modality
+    # exceeds this threshold. Catches paraphrase-level repeats that the
+    # UNIQUE(content, ...) constraint misses. 0.45 empirically: two word
+    # substitutions in a ~35-word prompt already drop 5-gram Jaccard to ~0.5,
+    # while genuinely distinct prompts score near 0.
+    NEAR_DUP_JACCARD = 0.45
+    NEAR_DUP_LOOKBACK = 200
+
     def __init__(self, db: ConnectionManager):
         self.db = db
+
+    @staticmethod
+    def _shingles(text: str, n: int = 5) -> set:
+        tokens = re.findall(r"[a-z']+", text.lower())
+        if len(tokens) < n:
+            return {tuple(tokens)}
+        return {tuple(tokens[i : i + n]) for i in range(len(tokens) - n + 1)}
+
+    def _is_near_duplicate(self, content: str, modality: Optional[str]) -> bool:
+        """True when content is a paraphrase-level repeat of a recent prompt."""
+        new_sh = self._shingles(content)
+        if not new_sh:
+            return False
+        with self.db.connect() as conn:
+            rows = conn.execute(
+                """
+                SELECT content FROM prompts
+                WHERE modality IS ?
+                ORDER BY created_at DESC LIMIT ?
+                """,
+                (modality, self.NEAR_DUP_LOOKBACK),
+            ).fetchall()
+        for (existing,) in rows:
+            if existing == content:
+                continue  # exact dups are handled by the UNIQUE constraint
+            old_sh = self._shingles(existing)
+            inter = len(new_sh & old_sh)
+            if inter and inter / len(new_sh | old_sh) > self.NEAR_DUP_JACCARD:
+                return True
+        return False
 
     # ------------------------------------------------------------------
     # CRUD
@@ -31,8 +71,11 @@ class PromptStore:
         event_count: Optional[int] = None,
         scene_json: Optional[str] = None,
         spec_json: Optional[str] = None,
-    ) -> str:
+    ) -> Optional[str]:
         """Insert a prompt, returning its id (or existing id if duplicate).
+
+        Returns None when the prompt is rejected as a near-duplicate of a
+        recent same-modality prompt (paraphrase-level repeat).
 
         The optional spec fields (register/length_band/event_count/scene_json/
         spec_json) record which sampled PromptSpec and VLM scene produced the
@@ -43,6 +86,13 @@ class PromptStore:
 
         prompt_id = str(uuid.uuid4())
         created_at = time.time()
+
+        if self._is_near_duplicate(content, modality):
+            bt.logging.debug(
+                f"Rejected near-duplicate prompt (modality={modality}): "
+                f"{content[:80]!r}..."
+            )
+            return None
 
         with self.db.connect() as conn:
             try:

--- a/gas/cache/db/prompt_store.py
+++ b/gas/cache/db/prompt_store.py
@@ -26,8 +26,19 @@ class PromptStore:
         content_type: str = "prompt",
         source_media_id: Optional[str] = None,
         modality: Optional[str] = None,
+        register: Optional[str] = None,
+        length_band: Optional[str] = None,
+        event_count: Optional[int] = None,
+        scene_json: Optional[str] = None,
+        spec_json: Optional[str] = None,
     ) -> str:
-        """Insert a prompt, returning its id (or existing id if duplicate)."""
+        """Insert a prompt, returning its id (or existing id if duplicate).
+
+        The optional spec fields (register/length_band/event_count/scene_json/
+        spec_json) record which sampled PromptSpec and VLM scene produced the
+        prompt, making prompt diversity auditable
+        (scripts/prompt_diversity_report.py).
+        """
         import sqlite3
 
         prompt_id = str(uuid.uuid4())
@@ -37,10 +48,26 @@ class PromptStore:
             try:
                 conn.execute(
                     """
-                    INSERT INTO prompts (id, content, content_type, modality, created_at, source_media_id)
-                    VALUES (?, ?, ?, ?, ?, ?)
+                    INSERT INTO prompts (
+                        id, content, content_type, modality, created_at,
+                        source_media_id, register, length_band, event_count,
+                        scene_json, spec_json
+                    )
+                    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                     """,
-                    (prompt_id, content, content_type, modality, created_at, source_media_id),
+                    (
+                        prompt_id,
+                        content,
+                        content_type,
+                        modality,
+                        created_at,
+                        source_media_id,
+                        register,
+                        length_band,
+                        event_count,
+                        scene_json,
+                        spec_json,
+                    ),
                 )
                 conn.commit()
                 return prompt_id

--- a/gas/evaluation/generative_challenge_manager.py
+++ b/gas/evaluation/generative_challenge_manager.py
@@ -122,16 +122,20 @@ class GenerativeChallengeManager:
             )
             return
 
-        # Assign random modality per miner, cycling prompts within each pool
+        # Assign random modality per miner, cycling prompts within each pool.
+        # Only modalities with non-empty pools are eligible — avoids silently
+        # skipping miners when one modality has no cached prompts.
         tasks = []
         modality_counters = {m: 0 for m in available}
         for uid in miner_uids:
-            mod = random.choice(available)
+            mods_with_prompts = [m for m in available if prompt_pools[m]]
+            if not mods_with_prompts:
+                break
+            mod = random.choice(mods_with_prompts)
             pool = prompt_pools[mod]
-            if pool:
-                ix = modality_counters[mod] % len(pool)
-                modality_counters[mod] += 1
-                tasks.append(self.send_generative_request(uid, pool[ix], mod))
+            ix = modality_counters[mod] % len(pool)
+            modality_counters[mod] += 1
+            tasks.append(self.send_generative_request(uid, pool[ix], mod))
 
         await asyncio.gather(*tasks)
 

--- a/gas/evaluation/generative_challenge_manager.py
+++ b/gas/evaluation/generative_challenge_manager.py
@@ -93,8 +93,7 @@ class GenerativeChallengeManager:
 
         bt.logging.info(f"Issuing generative challenge to UIDs: {miner_uids}")
 
-        # Sample one unique prompt per miner to prevent Sybil replay attacks.
-        # Modality selection driven by prompt_modalities config.
+        # Sample prompts per modality, then assign random modality per miner.
         raw = getattr(self.config, 'prompt_modalities', 'video')
         available = []
         for item in raw.split(','):
@@ -105,29 +104,34 @@ class GenerativeChallengeManager:
                 available.append(Modality.VIDEO)
         if not available:
             available = [Modality.VIDEO]
-        modality = random.choice(available)
+
+        # Pre-sample prompts for each modality
+        prompt_pools = {}
         n_needed = len(miner_uids)
-
-        prompt_entries = self.content_manager.sample_prompts(
-            k=n_needed, modality=modality.value, remove=False, strategy="least_used",
-        )
-        if len(prompt_entries) < n_needed:
-            bt.logging.info(
-                f"Only {len(prompt_entries)}/{n_needed} prompts available for {modality.value}. "
-                "Using what's available."
+        for mod in available:
+            entries = self.content_manager.sample_prompts(
+                k=n_needed, modality=mod.value, remove=False, strategy="least_used",
             )
+            prompt_pools[mod] = entries
 
-        if not prompt_entries:
+        # Check at least one pool has prompts
+        total_prompts = sum(len(v) for v in prompt_pools.values())
+        if total_prompts == 0:
             bt.logging.info(
                 "Waiting for prompt cache to be populated. Skipping generative challenge."
             )
             return
 
-        # Assign one unique prompt per miner, cycling if fewer prompts than miners
+        # Assign random modality per miner, cycling prompts within each pool
         tasks = []
-        for i, uid in enumerate(miner_uids):
-            prompt_entry = prompt_entries[i % len(prompt_entries)]
-            tasks.append(self.send_generative_request(uid, prompt_entry, modality))
+        modality_counters = {m: 0 for m in available}
+        for uid in miner_uids:
+            mod = random.choice(available)
+            pool = prompt_pools[mod]
+            if pool:
+                ix = modality_counters[mod] % len(pool)
+                modality_counters[mod] += 1
+                tasks.append(self.send_generative_request(uid, pool[ix], mod))
 
         await asyncio.gather(*tasks)
 

--- a/gas/generation/prompts/prompt_generator.py
+++ b/gas/generation/prompts/prompt_generator.py
@@ -388,18 +388,25 @@ class PromptGenerator:
                 Modality.IMAGE: sample_spec("image"),
                 Modality.VIDEO: sample_spec("video"),
             }
+            result = {}
             try:
-                image_prompt = self._compose(
+                result[Modality.IMAGE] = self._compose(
                     scene, kind="image", spec=scene_specs.get(Modality.IMAGE)
                 )
-                video_prompt = self._compose(
+            except Exception as e:
+                bt.logging.warning(f"LLM composition failed for scene (image): {e}")
+            try:
+                result[Modality.VIDEO] = self._compose(
                     scene, kind="video", spec=scene_specs.get(Modality.VIDEO)
                 )
-                self._log_generated_prompts(scene, image_prompt, video_prompt)
-                results.append({Modality.IMAGE: image_prompt, Modality.VIDEO: video_prompt})
             except Exception as e:
-                bt.logging.warning(f"LLM composition failed for scene: {e}")
-                results.append({})
+                bt.logging.warning(f"LLM composition failed for scene (video): {e}")
+            self._log_generated_prompts(
+                scene,
+                result.get(Modality.IMAGE, ""),
+                result.get(Modality.VIDEO, ""),
+            )
+            results.append(result)
         return results
 
     # ------------------------------------------------------------------

--- a/gas/generation/prompts/prompt_generator.py
+++ b/gas/generation/prompts/prompt_generator.py
@@ -53,6 +53,7 @@ from transformers import (
     pipeline,
 )
 
+from gas.generation.prompts.register_sampler import PromptSpec, sample_spec
 from gas.generation.prompts.scene import SceneDescription, extract_scene_with_vlm
 from gas.types import Modality
 
@@ -79,7 +80,10 @@ _VIDEO_SYSTEM = (
     "You write text-to-video prompts.\n\n"
     "You will receive a structured scene that a vision-language model "
     "extracted from a reference photograph, plus the same VLM's dense "
-    "caption of that image.\n\n"
+    "caption of that image. You may also receive a COMMITTED SHOT SPEC: "
+    "when present it is authoritative — register, camera behavior, length, "
+    "and event count are already decided; your job is only to realize them "
+    "vividly and plausibly for THIS scene.\n\n"
     "Your job: imagine the scene as a 5-10 second video clip and write "
     "a SINGLE fluent paragraph describing that clip. Match the visual "
     "register implied by the source — that might be a casual phone "
@@ -88,7 +92,8 @@ _VIDEO_SYSTEM = (
     "editorial shot, polished narrative cinema, or many other "
     "possibilities. Do not always default to polished cinematography.\n\n"
     "REQUIREMENTS\n"
-    "- 100-180 words, present tense, one paragraph, no line breaks.\n"
+    "- Present tense, one paragraph, no line breaks. Respect the length "
+    "given in the shot spec (or the user turn).\n"
     "- Make the scene visually concrete: subject + action, setting, "
     "what is moving, lighting and atmosphere. Include framing, camera "
     "behavior, lens, depth of field, color palette, or pacing only "
@@ -118,7 +123,9 @@ _IMAGE_SYSTEM = (
     "You write text-to-image prompts.\n\n"
     "You will receive a structured scene that a vision-language model "
     "extracted from a reference photograph, plus the same VLM's dense "
-    "caption of that image.\n\n"
+    "caption of that image. You may also receive a COMMITTED SHOT SPEC: "
+    "when present it is authoritative — register, length, and style "
+    "constraints are already decided; realize them for THIS scene.\n\n"
     "Your job: rewrite the scene as a SINGLE dense natural-language "
     "image prompt with maximum visual specificity. Match the visual "
     "register implied by the source — that might be a casual snapshot, "
@@ -127,7 +134,8 @@ _IMAGE_SYSTEM = (
     "other possibilities. Do not always default to polished editorial "
     "photography.\n\n"
     "REQUIREMENTS\n"
-    "- 60-120 words, one paragraph, no line breaks.\n"
+    "- One paragraph, no line breaks. Respect the length given in the "
+    "shot spec (or the user turn).\n"
     "- Lead with the most salient element for THIS scene; vary the "
     "structure across calls. Include framing, lens, color palette, "
     "lighting, mood, composition, or style/medium only when they fit "
@@ -343,12 +351,21 @@ class PromptGenerator:
         return scenes
 
     def compose_prompts_from_scenes(
-        self, scenes: list[SceneDescription]
+        self,
+        scenes: list[SceneDescription],
+        specs: Optional[list[dict]] = None,
     ) -> list[dict[Modality, str]]:
         """LLM-only: compose (image, video) prompts from cached scenes.
 
         Loads LLM if needed. Does NOT load or touch the VLM.
         Caller should call :meth:`unload_llm` after this to free ~60 GB.
+
+        Args:
+            scenes: One SceneDescription (or None) per source image.
+            specs: Optional list parallel to `scenes`; each entry is a dict
+                mapping Modality -> PromptSpec for that scene. When omitted,
+                a spec is sampled per scene per modality (so direct callers
+                still get diversified output).
 
         Returns one dict per input scene, mapping Modality -> prompt.
         Positions with ``None`` scenes produce empty dicts.
@@ -362,13 +379,21 @@ class PromptGenerator:
         self._prior_video_prompts.clear()
 
         results: list[dict[Modality, str]] = []
-        for scene in scenes:
+        for i, scene in enumerate(scenes):
             if scene is None:
                 results.append({})
                 continue
+            scene_specs = specs[i] if specs and i < len(specs) and specs[i] else {
+                Modality.IMAGE: sample_spec("image"),
+                Modality.VIDEO: sample_spec("video"),
+            }
             try:
-                image_prompt = self._compose(scene, kind="image")
-                video_prompt = self._compose(scene, kind="video")
+                image_prompt = self._compose(
+                    scene, kind="image", spec=scene_specs.get(Modality.IMAGE)
+                )
+                video_prompt = self._compose(
+                    scene, kind="video", spec=scene_specs.get(Modality.VIDEO)
+                )
                 self._log_generated_prompts(scene, image_prompt, video_prompt)
                 results.append({Modality.IMAGE: image_prompt, Modality.VIDEO: video_prompt})
             except Exception as e:
@@ -452,8 +477,18 @@ class PromptGenerator:
     # LLM composition
     # ------------------------------------------------------------------
 
-    def _compose(self, scene: SceneDescription, *, kind: str) -> str:
+    def _compose(
+        self,
+        scene: SceneDescription,
+        *,
+        kind: str,
+        spec: Optional[PromptSpec] = None,
+    ) -> str:
         """Single LLM forward pass that writes the canonical prompt for a modality.
+
+        When `spec` is provided, length budget and max_new_tokens follow the
+        sampled length band instead of the legacy fixed ranges, and the
+        committed spec block is injected into the user message.
 
         Returns the LLM output verbatim (with light whitespace cleanup).
         Raises on failure; the caller is the worker loop, which logs and
@@ -474,7 +509,11 @@ class PromptGenerator:
         else:
             raise ValueError(f"Unknown kind: {kind}")
 
-        user = self._build_user_message(scene, prior, length_spec)
+        if spec is not None:
+            # ~1.5 tokens/word headroom above the band ceiling.
+            max_new_tokens = min(max_new_tokens, int(spec.length_words[1] * 1.5) + 40)
+
+        user = self._build_user_message(scene, prior, length_spec, spec=spec)
 
         messages = [
             {"role": "system", "content": system},
@@ -500,8 +539,16 @@ class PromptGenerator:
         scene: SceneDescription,
         prior_prompts: Deque[str],
         length_spec: str,
+        spec: Optional["PromptSpec"] = None,
     ) -> str:
-        """Build the user turn: scene facts + dense caption + prior-prompt feedback.
+        """Build the user turn: committed spec + scene facts + dense caption + prior-prompt feedback.
+
+        `spec` (when provided) carries the sampled per-prompt axes —
+        register, camera behavior, length band, event budget, style
+        strictness — as COMMITTED facts the LLM must render. Sampling
+        these outside the LLM is what breaks the single-register,
+        single-voice monoculture: the LLM is a strong renderer but a
+        weak diversity source.
 
         `prior_prompts` is the recent per-modality composition history
         for the current batch (sliding window, capped at `_PRIOR_WINDOW`
@@ -514,7 +561,8 @@ class PromptGenerator:
         `length_spec` restates the system-prompt word range here in the
         user turn because LLMs weight closer-to-output instructions more
         heavily, and the verbose prior-prompt history was inflating
-        outputs above the system-prompt cap.
+        outputs above the system-prompt cap. When `spec` is provided it
+        supersedes `length_spec`.
         """
         scene_dict = asdict(scene)
         # Drop the dense caption from the JSON since we surface it
@@ -522,7 +570,50 @@ class PromptGenerator:
         caption = scene_dict.pop("caption", "")
         scene_json = json.dumps(scene_dict, indent=2, ensure_ascii=False)
 
-        parts = [
+        parts: List[str] = []
+
+        if spec is not None:
+            lo, hi = spec.length_words
+            spec_lines = [
+                "COMMITTED SHOT SPEC (authoritative — render exactly this, "
+                "do not negotiate):",
+                f"- register: {spec.register} — {spec.register_directives}",
+            ]
+            if spec.modality == "video":
+                spec_lines.append(f"- camera: {spec.camera_motion}")
+                if spec.event_count > 0:
+                    event_line = (
+                        f"- events: exactly {spec.event_count} discrete "
+                        "event(s) must occur mid-clip (someone/something "
+                        "enters, exits, passes, falls, or changes state — "
+                        "pick what fits the scene)"
+                    )
+                    if scene.plausible_events:
+                        event_line += (
+                            "; draw from: "
+                            + "; ".join(scene.plausible_events)
+                        )
+                    spec_lines.append(event_line)
+                else:
+                    spec_lines.append(
+                        "- events: none — ambient motion only, nothing "
+                        "discrete happens"
+                    )
+            spec_lines.append(f"- length: {lo}-{hi} words")
+            if spec.style_strictness == "plain":
+                banned = ", ".join(f'"{p}"' for p in spec.banned_phrases)
+                spec_lines.append(
+                    "- style: plain, factual, non-literary. Forbidden in "
+                    f"this register: similes, negation litanies, closing "
+                    f"aphorisms, and the phrases: {banned}"
+                )
+            else:
+                spec_lines.append(
+                    "- style: free — match the register's natural voice"
+                )
+            parts += ["\n".join(spec_lines), ""]
+
+        parts += [
             "Reference image, structured scene facts (from VLM):",
             scene_json,
             "",
@@ -546,11 +637,19 @@ class PromptGenerator:
                 history,
             ]
 
-        parts += [
-            "",
-            f"Strict length: {length_spec}. Do not exceed.",
-            "Compose the prompt now. Output the paragraph only.",
-        ]
+        if spec is not None:
+            lo, hi = spec.length_words
+            parts += [
+                "",
+                f"Strict length: {lo}-{hi} words. Do not exceed.",
+                "Compose the prompt now. Output the paragraph only.",
+            ]
+        else:
+            parts += [
+                "",
+                f"Strict length: {length_spec}. Do not exceed.",
+                "Compose the prompt now. Output the paragraph only.",
+            ]
         return "\n".join(parts)
 
     @staticmethod

--- a/gas/generation/prompts/prompt_generator.py
+++ b/gas/generation/prompts/prompt_generator.py
@@ -519,7 +519,10 @@ class PromptGenerator:
 
         if spec is not None:
             # ~1.5 tokens/word headroom above the band ceiling.
-            max_new_tokens = min(max_new_tokens, int(spec.length_words[1] * 1.5) + 40)
+            # The spec-derived budget replaces the legacy cap (which was
+            # sized for a single 60-120 image / 100-180 video band and
+            # would truncate long-band compositions).
+            max_new_tokens = int(spec.length_words[1] * 1.5) + 40
 
         user = self._build_user_message(scene, prior, length_spec, spec=spec)
 

--- a/gas/generation/prompts/prompt_generator.py
+++ b/gas/generation/prompts/prompt_generator.py
@@ -54,6 +54,7 @@ from transformers import (
 )
 
 from gas.generation.prompts.register_sampler import PromptSpec, sample_spec
+from gas.generation.prompts.prompt_qc import validate as qc_validate
 from gas.generation.prompts.scene import SceneDescription, extract_scene_with_vlm
 from gas.types import Modality
 
@@ -515,6 +516,27 @@ class PromptGenerator:
 
         user = self._build_user_message(scene, prior, length_spec, spec=spec)
 
+        text = self._generate_once(system, user, max_new_tokens, temperature)
+        ok, reason = qc_validate(text, spec)
+        if not ok:
+            bt.logging.debug(f"Prompt QC reject ({kind}): {reason}; retrying once")
+            retry_user = (
+                user
+                + f"\n\nPrevious attempt rejected: {reason}. "
+                "Fix exactly that problem and output the paragraph only."
+            )
+            text = self._generate_once(system, retry_user, max_new_tokens, temperature)
+            ok, reason = qc_validate(text, spec)
+            if not ok:
+                raise ValueError(f"Prompt failed QC twice ({kind}): {reason}")
+
+        prior.append(text)
+        return text
+
+    def _generate_once(
+        self, system: str, user: str, max_new_tokens: int, temperature: float
+    ) -> str:
+        """One LLM call + cleanup. Split out so the QC retry path can reuse it."""
         messages = [
             {"role": "system", "content": system},
             {"role": "user", "content": user},
@@ -530,9 +552,7 @@ class PromptGenerator:
             return_full_text=False,
             pad_token_id=self.llm.tokenizer.eos_token_id,
         )
-        text = self._clean_output(out[0]["generated_text"])
-        prior.append(text)
-        return text
+        return self._clean_output(out[0]["generated_text"])
 
     @staticmethod
     def _build_user_message(

--- a/gas/generation/prompts/prompt_qc.py
+++ b/gas/generation/prompts/prompt_qc.py
@@ -16,6 +16,13 @@ from typing import Optional, Tuple
 
 from gas.generation.prompts.register_sampler import PromptSpec
 
+# Tokenizer for word-boundary-aware phrase matching.
+_WORD_RE = re.compile(r"[a-z']+")
+
+
+def _tokens(text: str) -> list[str]:
+    return _WORD_RE.findall(text.lower())
+
 # Tolerance around the committed word band (fraction of the bound).
 _BAND_TOLERANCE = 0.20
 
@@ -75,9 +82,12 @@ def validate(text: str, spec: Optional[PromptSpec]) -> Tuple[bool, str]:
         )
 
     if spec.style_strictness == "plain" and spec.banned_phrases:
-        lowered = text.lower()
+        words = _tokens(text)
         for phrase in spec.banned_phrases:
-            if phrase in lowered:
-                return False, f"banned phrase for plain register: {phrase!r}"
+            phrase_tokens = _tokens(phrase)
+            plen = len(phrase_tokens)
+            for i in range(len(words) - plen + 1):
+                if words[i : i + plen] == phrase_tokens:
+                    return False, f"banned phrase for plain register: {phrase!r}"
 
     return True, ""

--- a/gas/generation/prompts/prompt_qc.py
+++ b/gas/generation/prompts/prompt_qc.py
@@ -1,0 +1,83 @@
+"""Validity gate for composed prompts.
+
+A composed prompt must look like a usable text-to-media prompt — not LLM
+meta-chatter, not structural markup, not wildly off the committed length
+band, and (for plain registers) free of the literary house-style tells the
+register forbids. Rejected prompts are retried once by the composer with the
+rejection reason appended; a second failure drops the sample.
+
+Pure stdlib; unit-testable without models.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Optional, Tuple
+
+from gas.generation.prompts.register_sampler import PromptSpec
+
+# Tolerance around the committed word band (fraction of the bound).
+_BAND_TOLERANCE = 0.20
+
+# Case-insensitive prefixes/fragments that mark LLM meta-output rather than
+# a prompt. Checked anywhere in the first 80 chars.
+_META_PATTERNS = (
+    "here is",
+    "here's",
+    "this prompt",
+    "committed shot spec",
+    "as an ai",
+    "i cannot",
+    "i can't",
+    "sure!",
+    "certainly",
+    "note:",
+    "output:",
+)
+
+_STRUCTURE_RE = re.compile(r"(^|\n)\s*([-*•]\s|\d+\.\s|#+\s)")
+
+
+def validate(text: str, spec: Optional[PromptSpec]) -> Tuple[bool, str]:
+    """Validate a composed prompt against its committed spec.
+
+    Args:
+        text: The cleaned composer output.
+        spec: The PromptSpec it was composed under, or None (legacy path —
+            only meta/markup checks apply).
+
+    Returns:
+        (ok, reason): ok=True with empty reason, or ok=False with a short
+        human-readable reason suitable for appending to a retry message.
+    """
+    if not text or not text.strip():
+        return False, "empty output"
+
+    head = text[:80].lower()
+    for pat in _META_PATTERNS:
+        if pat in head:
+            return False, f"meta-text detected ({pat!r})"
+
+    if _STRUCTURE_RE.search(text):
+        return False, "structural markup (bullets/headings/numbering)"
+
+    if spec is None:
+        return True, ""
+
+    words = len(re.findall(r"\S+", text))
+    lo, hi = spec.length_words
+    min_ok = int(lo * (1 - _BAND_TOLERANCE))
+    max_ok = int(hi * (1 + _BAND_TOLERANCE))
+    if words < min_ok or words > max_ok:
+        return False, (
+            f"length {words} words outside committed band "
+            f"{lo}-{hi} (tolerance {min_ok}-{max_ok})"
+        )
+
+    if spec.style_strictness == "plain" and spec.banned_phrases:
+        lowered = text.lower()
+        for phrase in spec.banned_phrases:
+            if phrase in lowered:
+                return False, f"banned phrase for plain register: {phrase!r}"
+
+    return True, ""

--- a/gas/generation/prompts/prompt_qc.py
+++ b/gas/generation/prompts/prompt_qc.py
@@ -24,7 +24,7 @@ def _tokens(text: str) -> list[str]:
     return _WORD_RE.findall(text.lower())
 
 # Tolerance around the committed word band (fraction of the bound).
-_BAND_TOLERANCE = 0.20
+_BAND_TOLERANCE = 0.25
 
 # Case-insensitive prefixes/fragments that mark LLM meta-output rather than
 # a prompt. Checked anywhere in the first 80 chars.

--- a/gas/generation/prompts/register_sampler.py
+++ b/gas/generation/prompts/register_sampler.py
@@ -141,9 +141,9 @@ PLAIN_BANNED_PHRASES: Tuple[str, ...] = (
 
 # Length bands: (probability, (min_words, max_words))
 _LENGTH_BANDS: Dict[str, Tuple[float, Tuple[int, int]]] = {
-    "short": (0.25, (25, 60)),
-    "medium": (0.45, (60, 110)),
-    "long": (0.30, (110, 180)),
+    "short": (0.25, (50, 90)),
+    "medium": (0.45, (90, 140)),
+    "long": (0.30, (140, 210)),
 }
 
 # Event count distribution for video prompts.

--- a/gas/generation/prompts/register_sampler.py
+++ b/gas/generation/prompts/register_sampler.py
@@ -1,0 +1,240 @@
+"""Per-prompt register / structure sampling for gasstation prompt composition.
+
+This module is the diversity SOURCE for prompt generation. The composer LLM is
+a strong renderer but a weak source of variety: left to choose register, shot
+structure, length, and style on its own it collapses into a single mode
+(locked-off shallow-DoF close-ups in literary prose). So those axes are
+sampled HERE, explicitly and auditably, and injected into the composition
+prompt as committed facts the LLM must render.
+
+Pure stdlib, no model dependencies; fully unit-testable.
+
+The ``weights_override`` argument of :func:`sample_spec` is the future hook
+for a discriminator-feedback loop (bias register weights toward regions where
+detectors are currently strong). Keep it a plain dict of register-name ->
+weight so a downstream job can compute it from challenge outcomes.
+"""
+
+from __future__ import annotations
+
+import random
+from dataclasses import dataclass, field, asdict
+from typing import Dict, List, Optional, Tuple
+
+
+# ---------------------------------------------------------------------------
+# Register table
+# ---------------------------------------------------------------------------
+
+@dataclass(frozen=True)
+class Register:
+    """A visual register: how the clip/photo was plausibly captured."""
+
+    name: str
+    weight: float
+    directives: str                       # rendered into the committed spec block
+    camera_motions: Tuple[str, ...]       # sampled per prompt (video only)
+    strictness: str = "free"              # "plain" bans literary devices
+    image_ok: bool = True                 # register applies to still images too
+
+
+# Weights lean toward what actually circulates in real media, not uniform.
+REGISTERS: Tuple[Register, ...] = (
+    Register(
+        "phone_casual", 0.20,
+        "casual phone capture; imperfect framing, slight tilt, ordinary "
+        "lighting, plain colloquial description",
+        ("handheld drift", "slow pan", "walking motion", "static handheld"),
+        strictness="plain",
+    ),
+    Register(
+        "phone_vertical", 0.10,
+        "vertical phone video; held at arm's length or chest height, "
+        "everyday context, plain language",
+        ("handheld drift", "walking motion", "static handheld"),
+        strictness="plain",
+    ),
+    Register(
+        "cctv_surveillance", 0.08,
+        "fixed security camera; high mounted angle, wide coverage, flat "
+        "utilitarian color, no artistic treatment, plain factual language",
+        ("static",),
+        strictness="plain",
+    ),
+    Register(
+        "dashcam", 0.05,
+        "dashboard camera; wide lens, hood or dashboard edge visible, "
+        "scene moves past the fixed mount, plain factual language",
+        ("fixed mount, scene moves past",),
+        strictness="plain",
+        image_ok=False,
+    ),
+    Register(
+        "home_video", 0.07,
+        "home video; amateur operator, occasional zoom or reframe, warm "
+        "domestic context, plain language",
+        ("shaky handheld", "amateur zoom", "reframing pans"),
+        strictness="plain",
+    ),
+    Register(
+        "news_broadcast", 0.07,
+        "broadcast news; tripod mid-shot or standup framing, even "
+        "professional lighting, correspondent or b-roll register",
+        ("static tripod", "slow pan", "slow zoom"),
+    ),
+    Register(
+        "documentary", 0.08,
+        "observational documentary; deliberate but unpolished, natural "
+        "light, patient framing",
+        ("static tripod", "slow pan", "handheld follow"),
+    ),
+    Register(
+        "drone_aerial", 0.05,
+        "aerial drone; high vantage, gliding movement, wide landscape "
+        "or overhead geometry",
+        ("gliding forward", "slow orbit", "rising reveal", "static hover"),
+    ),
+    Register(
+        "screen_recording", 0.04,
+        "screen recording; software UI, cursor movement, flat rendering, "
+        "plain technical description",
+        ("static screen", "scrolling content"),
+        strictness="plain",
+    ),
+    Register(
+        "animation_3d", 0.05,
+        "3D rendered animation; stylized materials and lighting, "
+        "deliberate camera",
+        ("smooth dolly", "orbit", "static", "push-in"),
+    ),
+    Register(
+        "webcam_stream", 0.06,
+        "webcam or stream capture; fixed near framing, compressed look, "
+        "desk or room context, plain language",
+        ("static",),
+        strictness="plain",
+    ),
+    Register(
+        "cinema_polished", 0.15,
+        "polished narrative cinematography; full control of lens, light, "
+        "and movement; cinematographic vocabulary appropriate",
+        ("static tripod", "slow push-in", "dolly", "tracking", "crane",
+         "handheld vérité"),
+    ),
+)
+
+_TOTAL_WEIGHT = sum(r.weight for r in REGISTERS)
+
+# Phrases banned in "plain" registers — the house-style tells measured by
+# scripts/prompt_diversity_report.py.
+PLAIN_BANNED_PHRASES: Tuple[str, ...] = (
+    "as if",
+    "as though",
+    "no breath",
+    "monochrome",
+    "palpable",
+    "charged",
+    "unspoken",
+    "the weight of",
+    "stillness",
+)
+
+# Length bands: (probability, (min_words, max_words))
+_LENGTH_BANDS: Dict[str, Tuple[float, Tuple[int, int]]] = {
+    "short": (0.25, (25, 60)),
+    "medium": (0.45, (60, 110)),
+    "long": (0.30, (110, 180)),
+}
+
+# Event count distribution for video prompts.
+_EVENT_DIST: Tuple[Tuple[int, float], ...] = ((0, 0.35), (1, 0.45), (2, 0.20))
+
+
+@dataclass
+class PromptSpec:
+    """Committed per-prompt axes, sampled before composition."""
+
+    modality: str
+    register: str
+    register_directives: str
+    camera_motion: str
+    length_band: str
+    length_words: Tuple[int, int]
+    event_count: int
+    style_strictness: str
+    banned_phrases: Tuple[str, ...] = field(default_factory=tuple)
+    origin: str = "vlm"  # "vlm" | "remix"
+
+    def to_dict(self) -> dict:
+        d = asdict(self)
+        d["length_words"] = list(self.length_words)
+        d["banned_phrases"] = list(self.banned_phrases)
+        return d
+
+
+def _weighted_choice(rng: random.Random, items, weights) -> int:
+    total = sum(weights)
+    x = rng.uniform(0, total)
+    acc = 0.0
+    for i, w in enumerate(weights):
+        acc += w
+        if x <= acc:
+            return i
+    return len(items) - 1
+
+
+def sample_spec(
+    modality: str,
+    rng_seed: Optional[int] = None,
+    weights_override: Optional[Dict[str, float]] = None,
+) -> PromptSpec:
+    """Sample the committed axes for one prompt.
+
+    Args:
+        modality: "image" or "video".
+        rng_seed: Optional seed for deterministic sampling (tests).
+        weights_override: Optional register-name -> weight map replacing the
+            default weights (feedback-loop hook). Registers absent from the
+            map get weight 0.
+    """
+    rng = random.Random(rng_seed)
+
+    candidates: List[Register] = [
+        r for r in REGISTERS if (modality == "video" or r.image_ok)
+    ]
+    if weights_override:
+        weights = [weights_override.get(r.name, 0.0) for r in candidates]
+        if sum(weights) <= 0:
+            weights = [r.weight for r in candidates]
+    else:
+        weights = [r.weight for r in candidates]
+
+    reg = candidates[_weighted_choice(rng, candidates, weights)]
+
+    band_names = list(_LENGTH_BANDS)
+    band_probs = [_LENGTH_BANDS[b][0] for b in band_names]
+    band = band_names[_weighted_choice(rng, band_names, band_probs)]
+    length_words = _LENGTH_BANDS[band][1]
+
+    if modality == "video":
+        camera_motion = rng.choice(reg.camera_motions)
+        counts = [c for c, _ in _EVENT_DIST]
+        probs = [p for _, p in _EVENT_DIST]
+        event_count = counts[_weighted_choice(rng, counts, probs)]
+    else:
+        camera_motion = ""
+        event_count = 0
+
+    banned = PLAIN_BANNED_PHRASES if reg.strictness == "plain" else ()
+
+    return PromptSpec(
+        modality=modality,
+        register=reg.name,
+        register_directives=reg.directives,
+        camera_motion=camera_motion,
+        length_band=band,
+        length_words=length_words,
+        event_count=event_count,
+        style_strictness=reg.strictness,
+        banned_phrases=banned,
+    )

--- a/gas/generation/prompts/register_sampler.py
+++ b/gas/generation/prompts/register_sampler.py
@@ -141,9 +141,9 @@ PLAIN_BANNED_PHRASES: Tuple[str, ...] = (
 
 # Length bands: (probability, (min_words, max_words))
 _LENGTH_BANDS: Dict[str, Tuple[float, Tuple[int, int]]] = {
-    "short": (0.25, (50, 90)),
-    "medium": (0.45, (90, 140)),
-    "long": (0.30, (140, 210)),
+    "short": (0.25, (80, 130)),
+    "medium": (0.45, (130, 180)),
+    "long": (0.30, (180, 240)),
 }
 
 # Event count distribution for video prompts.

--- a/gas/generation/prompts/scene.py
+++ b/gas/generation/prompts/scene.py
@@ -59,6 +59,7 @@ class SceneDescription:
     framing: str = "unknown"
     style: str = ""
     mood: str = ""
+    plausible_events: List[str] = field(default_factory=list)
 
     def to_dict(self) -> Dict[str, Any]:
         return asdict(self)
@@ -75,7 +76,12 @@ class SceneDescription:
         if not caption:
             raise ValueError("SceneDescription requires a non-empty caption")
 
-        for list_field in ("static_elements", "dynamic_candidates", "observed_motion_cues"):
+        for list_field in (
+            "static_elements",
+            "dynamic_candidates",
+            "observed_motion_cues",
+            "plausible_events",
+        ):
             value = clean.get(list_field)
             if value is None:
                 clean[list_field] = []
@@ -142,6 +148,10 @@ _SCHEMA_INSTRUCTION = (
     "- observed_motion_cues: list of motion signals already visible in the "
     "image (e.g. ['hair blowing left', 'visible motion blur on cyclist', "
     "'water surface ripples', 'tilted gait']). Use [] if none.\n"
+    "- plausible_events: list of 2-4 discrete events that could believably "
+    "happen in this scene within 10 seconds (e.g. ['a waiter passes behind "
+    "him', 'the phone on the desk lights up', 'a gust scatters the napkins', "
+    "'a car crosses the intersection']). Ground them in what the image shows.\n"
     "- camera_distance: one of [close-up, medium, wide, aerial].\n"
     "- framing: one of [portrait, landscape, square].\n"
     "- style: short phrase (e.g. 'documentary photography', 'cinematic', "

--- a/gas/generation/prompts/scene_remix.py
+++ b/gas/generation/prompts/scene_remix.py
@@ -1,0 +1,111 @@
+"""Scene recombination: semi-synthetic scenes from real VLM extractions.
+
+Takes a pixel-grounded SceneDescription and resamples 1-3 contextual fields
+(time of day, weather, setting, environment, mood) while preserving the
+subject. This breaks the scraper's distributional bias (whatever the source
+images over-represent) without giving up the correlational texture of real
+scenes — most of the structure stays grounded; only a few axes move.
+
+Used for a fraction of each prompt batch (see generator_service). Remixed
+scenes flow through the same committed-spec composition and QC as VLM scenes.
+
+Pure stdlib; deterministic under a seeded random.Random.
+"""
+
+from __future__ import annotations
+
+import random
+from dataclasses import replace as dc_replace
+from typing import List, Optional, Sequence
+
+from gas.generation.prompts.scene import SceneDescription
+
+_TIMES = [
+    "dawn", "morning", "midday", "afternoon", "golden hour",
+    "sunset", "dusk", "evening", "night",
+]
+_WEATHER = [
+    "clear", "partly cloudy", "overcast", "foggy", "rainy", "snowy", "stormy",
+]
+_ENVIRONMENTS = ["indoor", "outdoor", "mixed"]
+_MOODS = [
+    "serene", "tense", "joyful", "melancholic", "mundane", "chaotic",
+    "festive", "lonely", "businesslike", "playful",
+]
+
+# Fallback settings when no empirical pool is provided. Deliberately
+# ordinary — the point is coverage of unglamorous reality, not spectacle.
+_DEFAULT_SETTINGS = [
+    "supermarket aisle", "parking garage", "suburban kitchen", "bus interior",
+    "office cubicle", "laundromat", "roadside diner", "school hallway",
+    "construction site", "underground station platform", "backyard patio",
+    "hotel corridor", "indoor market", "riverside path", "rooftop terrace",
+]
+
+# Fields eligible for resampling, with their value pools (setting handled
+# separately because its pool can be empirical).
+_FIELD_POOLS = {
+    "time_of_day": _TIMES,
+    "weather": _WEATHER,
+    "environment_type": _ENVIRONMENTS,
+    "mood": _MOODS,
+}
+
+_MUTABLE_FIELDS = ("time_of_day", "weather", "setting", "environment_type", "mood")
+
+
+def remix(
+    scene: SceneDescription,
+    rng: random.Random,
+    setting_pool: Optional[Sequence[str]] = None,
+) -> SceneDescription:
+    """Return a new SceneDescription with 1-3 contextual fields resampled.
+
+    Args:
+        scene: Source scene (not mutated).
+        rng: Seeded random source (caller controls determinism).
+        setting_pool: Optional empirical pool of settings (e.g. drawn from
+            the prompts DB scene_json column). Falls back to a built-in
+            list of ordinary locations.
+
+    Invariants:
+        - `subject` is always preserved.
+        - When `time_of_day` changes, `lighting` and `color_palette` are
+          cleared so the composer re-derives them instead of inheriting
+          values that no longer make sense.
+        - The dense `caption` is replaced with a minimal stub built from
+          subject + setting, so the composer cannot copy the original
+          pixels' description verbatim.
+    """
+    k = rng.randint(1, 3)
+    fields: List[str] = list(rng.sample(_MUTABLE_FIELDS, k))
+
+    updates = {}
+    for field in fields:
+        if field == "setting":
+            pool = list(setting_pool) if setting_pool else _DEFAULT_SETTINGS
+            choices = [s for s in pool if s and s != scene.setting]
+            if choices:
+                updates["setting"] = rng.choice(choices)
+        else:
+            pool = _FIELD_POOLS[field]
+            current = getattr(scene, field)
+            choices = [v for v in pool if v != current]
+            updates[field] = rng.choice(choices)
+
+    if "time_of_day" in updates:
+        updates["lighting"] = ""
+        updates["color_palette"] = ""
+
+    new_setting = updates.get("setting", scene.setting)
+    stub_bits = [scene.subject or "the subject"]
+    if new_setting:
+        stub_bits.append(f"in {new_setting}")
+    updates["caption"] = " ".join(stub_bits) + "."
+
+    # Observed cues belong to the original pixels; a remixed context can
+    # keep dynamic candidates (they travel with the subject) but observed
+    # motion cues may contradict the new context.
+    updates["observed_motion_cues"] = []
+
+    return dc_replace(scene, **updates)

--- a/gas/generation/prompts/scene_remix.py
+++ b/gas/generation/prompts/scene_remix.py
@@ -103,9 +103,11 @@ def remix(
         stub_bits.append(f"in {new_setting}")
     updates["caption"] = " ".join(stub_bits) + "."
 
-    # Observed cues belong to the original pixels; a remixed context can
-    # keep dynamic candidates (they travel with the subject) but observed
-    # motion cues may contradict the new context.
+    # Observed cues and plausible_events are both grounded in the original
+    # pixels; a remixed context (different time of day, weather, or
+    # setting) can make them misleading.  Dynamic candidates travel with
+    # the subject and stay.
     updates["observed_motion_cues"] = []
+    updates["plausible_events"] = []
 
     return dc_replace(scene, **updates)

--- a/neurons/validator/services/generator_service.py
+++ b/neurons/validator/services/generator_service.py
@@ -504,18 +504,48 @@ class GeneratorService:
         # ------------------------------------------------------------------
         # Phase 3: LLM stage — compose prompts from cached scenes (LLM only)
         # ------------------------------------------------------------------
-        prompts_list = self.prompt_generator.compose_prompts_from_scenes(scenes)
+        # Sample the committed per-prompt axes (register, camera, length,
+        # events) OUTSIDE the LLM so prompt diversity is explicit and
+        # auditable rather than left to the composer's collapsed prior.
+        from gas.generation.prompts.register_sampler import sample_spec
+
+        specs = [
+            {
+                Modality.IMAGE: sample_spec("image"),
+                Modality.VIDEO: sample_spec("video"),
+            }
+            if scene is not None
+            else {}
+            for scene in scenes
+        ]
+        prompts_list = self.prompt_generator.compose_prompts_from_scenes(
+            scenes, specs=specs
+        )
         self.prompt_generator.unload_llm()
 
         # ------------------------------------------------------------------
         # Phase 4: Write results to database
         # ------------------------------------------------------------------
-        for item, prompts in zip(items, prompts_list):
+        import json as _json
+        from dataclasses import asdict as _asdict
+
+        for item, scene, scene_specs, prompts in zip(items, scenes, specs, prompts_list):
+            scene_blob = (
+                _json.dumps(_asdict(scene), ensure_ascii=False)
+                if scene is not None
+                else None
+            )
             for modality, prompt in prompts.items():
+                spec = scene_specs.get(modality)
                 self.content_manager.write_prompt(
                     content=prompt,
                     source_media_id=item["id"],
                     modality=modality.value,
+                    register=spec.register if spec else None,
+                    length_band=spec.length_band if spec else None,
+                    event_count=spec.event_count if spec else None,
+                    scene_json=scene_blob,
+                    spec_json=_json.dumps(spec.to_dict()) if spec else None,
                 )
                 generated += 1
 

--- a/neurons/validator/services/generator_service.py
+++ b/neurons/validator/services/generator_service.py
@@ -446,6 +446,37 @@ class GeneratorService:
                 continue
         return {"count": 0, "items": []}
 
+    def _recent_settings_pool(self, limit: int = 200) -> list:
+        """Empirical pool of scene settings from recent prompts' scene_json.
+
+        Used by the scene-remix path so resampled settings follow the
+        real-world distribution of observed locations rather than a
+        hardcoded list. Returns [] on any failure (remix falls back to its
+        built-in defaults).
+        """
+        import json as _json
+
+        try:
+            with self.content_manager.db.connect() as conn:
+                rows = conn.execute(
+                    "SELECT scene_json FROM prompts "
+                    "WHERE scene_json IS NOT NULL "
+                    "ORDER BY created_at DESC LIMIT ?",
+                    (limit,),
+                ).fetchall()
+            pool = []
+            for (blob,) in rows:
+                try:
+                    setting = (_json.loads(blob).get("setting") or "").strip()
+                    if setting:
+                        pool.append(setting)
+                except Exception:
+                    continue
+            return pool
+        except Exception as e:
+            bt.logging.debug(f"[GENERATOR-SERVICE] settings pool unavailable: {e}")
+            return []
+
     def _active_prompt_modalities(self) -> set:
         raw = getattr(self.config, 'prompt_modalities', 'video')
         mods = set()
@@ -503,6 +534,30 @@ class GeneratorService:
             return 0
 
         # ------------------------------------------------------------------
+        # Phase 2b: Scene remix — append semi-synthetic variants for ~25%
+        # of successfully extracted scenes. Breaks scraper-distribution
+        # inheritance while keeping most of the real scene's structure.
+        # ------------------------------------------------------------------
+        import random as _random
+
+        from gas.generation.prompts.scene_remix import remix
+
+        rng = _random.Random()
+        setting_pool = self._recent_settings_pool()
+        origins = ["vlm"] * len(scenes)
+        remix_sources = [
+            (i, s) for i, s in enumerate(scenes) if s is not None
+        ]
+        n_remix = max(0, int(len(remix_sources) * 0.25))
+        for i, source_scene in rng.sample(remix_sources, n_remix) if n_remix else []:
+            try:
+                scenes.append(remix(source_scene, rng, setting_pool=setting_pool))
+                items.append(items[i])  # same source media row
+                origins.append("remix")
+            except Exception as e:
+                bt.logging.warning(f"Scene remix failed: {e}")
+
+        # ------------------------------------------------------------------
         # Phase 3: LLM stage — compose prompts from cached scenes (LLM only)
         # ------------------------------------------------------------------
         # Sample the committed per-prompt axes (register, camera, length,
@@ -519,6 +574,10 @@ class GeneratorService:
             else {}
             for scene in scenes
         ]
+        # Tag remixed scenes so the audit can separate the two populations.
+        for scene_specs, origin in zip(specs, origins):
+            for spec in scene_specs.values():
+                spec.origin = origin
         prompts_list = self.prompt_generator.compose_prompts_from_scenes(
             scenes, specs=specs
         )
@@ -554,7 +613,8 @@ class GeneratorService:
                     generated += 1
 
         bt.logging.info(
-            f"[GENERATOR-SERVICE] Added {generated} prompts to database"
+            f"[GENERATOR-SERVICE] Added {generated} prompts to database "
+            f"({origins.count('vlm')} vlm + {origins.count('remix')} remix scenes)"
             + (f" ({skipped_dups} near-duplicates skipped)" if skipped_dups else "")
         )
         return generated

--- a/neurons/validator/services/generator_service.py
+++ b/neurons/validator/services/generator_service.py
@@ -468,6 +468,7 @@ class GeneratorService:
         peak VRAM at ~60 GB instead of ~69 GB.
         """
         generated = 0
+        skipped_dups = 0
 
         # ------------------------------------------------------------------
         # Phase 1: Collect images for the batch
@@ -537,7 +538,7 @@ class GeneratorService:
             )
             for modality, prompt in prompts.items():
                 spec = scene_specs.get(modality)
-                self.content_manager.write_prompt(
+                prompt_id = self.content_manager.write_prompt(
                     content=prompt,
                     source_media_id=item["id"],
                     modality=modality.value,
@@ -547,9 +548,15 @@ class GeneratorService:
                     scene_json=scene_blob,
                     spec_json=_json.dumps(spec.to_dict()) if spec else None,
                 )
-                generated += 1
+                if prompt_id is None:
+                    skipped_dups += 1
+                else:
+                    generated += 1
 
-        bt.logging.info(f"[GENERATOR-SERVICE] Added {generated} prompts to database")
+        bt.logging.info(
+            f"[GENERATOR-SERVICE] Added {generated} prompts to database"
+            + (f" ({skipped_dups} near-duplicates skipped)" if skipped_dups else "")
+        )
         return generated
 
     def _models_for_modality(self, modality: Modality) -> list:

--- a/neurons/validator/services/generator_service.py
+++ b/neurons/validator/services/generator_service.py
@@ -224,6 +224,9 @@ class GeneratorService:
         """Main generation loop."""
         bt.logging.info("[GENERATOR-SERVICE] Starting generation work loop")
 
+        # Clear any pending verification backlog before the first generation cycle.
+        self._run_verification()
+
         while not self._stop_requested.is_set():
             try:
                 self._await_media(min_needed=1, max_wait_s=1200, poll_s=10)

--- a/neurons/validator/validator.py
+++ b/neurons/validator/validator.py
@@ -2,6 +2,7 @@ import asyncio
 import sys
 import json
 import traceback
+import time
 from time import sleep
 from threading import Thread
 
@@ -339,14 +340,16 @@ class Validator(BaseNeuron):
         alpha = 0.5
         self.scores = alpha * reward_arr + (1 - alpha) * self.scores
 
-        # Hard cutoff: zero out scores for generators not active within liveness window
-        # This prevents inactive miners from retaining any accumulated score via EMA decay
+        # Hard cutoff: zero out scores for generators not active within liveness window.
+        # Checks the actual last_seen timestamp, not just dict membership.
         if generator_liveness:
+            cutoff = time.time() - max_inactive_hours * 3600
             inactive_count = 0
             for uid in range(len(self.scores)):
-                if uid < len(self.metagraph.hotkeys):
+                if uid < len(self.metagraph.hotkeys) and self.scores[uid] > 0:
                     hotkey = self.metagraph.hotkeys[uid]
-                    if hotkey not in generator_liveness and self.scores[uid] > 0:
+                    last_seen = generator_liveness.get(hotkey, 0)
+                    if last_seen < cutoff:
                         self.scores[uid] = 0
                         inactive_count += 1
             if inactive_count > 0:

--- a/scripts/prompt_diversity_report.py
+++ b/scripts/prompt_diversity_report.py
@@ -1,0 +1,273 @@
+#!/usr/bin/env python3
+"""Prompt diversity report for the SN34 gasstation prompts DB.
+
+Quantifies concentration bias in generated prompts: opener n-gram share,
+length distribution, vocabulary fingerprints, phrase tells, near-duplicates,
+and (when the new columns exist) register/spec distribution.
+
+Usage:
+    python scripts/prompt_diversity_report.py --db ~/.cache/sn34/prompts.db
+    python scripts/prompt_diversity_report.py --db prompts.db --json
+    python scripts/prompt_diversity_report.py --db prompts.db --check  # exit 1 on threshold breach
+
+No dependencies beyond stdlib. Optional: --embed uses sentence-transformers
+if installed (skipped gracefully otherwise).
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import re
+import sqlite3
+import sys
+from collections import Counter
+from itertools import combinations
+from pathlib import Path
+
+# ---------------------------------------------------------------------------
+# Thresholds for --check mode (Phase 4 canary). Tuned per the improvement
+# plan: docs/plans reference 2026-06-10-prompt-engine-improvement-plan.md.
+# ---------------------------------------------------------------------------
+THRESHOLDS = {
+    "max_opener_trigram_share": 0.15,   # no single 3-word opener > 15%
+    "min_registers_per_100": 8,         # spec sampling spread (needs register col)
+    "max_register_share": 0.35,         # no register > 35%
+    "max_phrase_tell_rate": 0.30,       # "as if" etc. per prompt
+    "max_near_dup_rate": 0.02,
+}
+
+PHRASE_TELLS = [
+    "as if", "not from", "no breath", "the camera", "close-up", "monochrome",
+    "charcoal", "slate", "palpable", "unspoken", "stillness", "tremor",
+]
+
+STOPWORDS = set(
+    "a an the of in on at to and or but is are was were be been with for "
+    "from by as its his her their it he she they this that into over under "
+    "no not only just like through across behind beneath beyond".split()
+)
+
+WORD_RE = re.compile(r"[a-z']+")
+
+
+def tokenize(text: str) -> list[str]:
+    return WORD_RE.findall(text.lower())
+
+
+def shingles(tokens: list[str], n: int = 5) -> set:
+    if len(tokens) < n:
+        return {tuple(tokens)}
+    return {tuple(tokens[i : i + n]) for i in range(len(tokens) - n + 1)}
+
+
+def jaccard(a: set, b: set) -> float:
+    if not a or not b:
+        return 0.0
+    return len(a & b) / len(a | b)
+
+
+def length_bucket(n: int) -> str:
+    if n < 40:
+        return "<40"
+    if n < 80:
+        return "40-79"
+    if n < 120:
+        return "80-119"
+    if n < 160:
+        return "120-159"
+    return "160+"
+
+
+def load_prompts(db_path: Path) -> list[dict]:
+    conn = sqlite3.connect(str(db_path))
+    conn.row_factory = sqlite3.Row
+    cols = {r[1] for r in conn.execute("PRAGMA table_info(prompts)")}
+    select = ["id", "content", "modality", "created_at"]
+    for optional in ("register", "length_band", "event_count", "spec_json"):
+        if optional in cols:
+            select.append(optional)
+    rows = conn.execute(
+        f"SELECT {', '.join(select)} FROM prompts ORDER BY created_at DESC"
+    ).fetchall()
+    conn.close()
+    return [dict(r) for r in rows]
+
+
+def analyze(prompts: list[dict], near_dup_sample: int = 400) -> dict:
+    out: dict = {"total": len(prompts), "modalities": {}}
+    by_mod: dict[str, list[dict]] = {}
+    for p in prompts:
+        by_mod.setdefault(p.get("modality") or "unknown", []).append(p)
+
+    for mod, items in sorted(by_mod.items()):
+        texts = [p["content"] for p in items]
+        token_lists = [tokenize(t) for t in texts]
+        n = len(texts)
+
+        # Length histogram
+        lengths = [len(toks) for toks in token_lists]
+        hist = Counter(length_bucket(l) for l in lengths)
+
+        # Opener trigrams
+        openers = Counter(
+            " ".join(toks[:3]) for toks in token_lists if len(toks) >= 3
+        )
+        top_openers = openers.most_common(10)
+        max_opener_share = (top_openers[0][1] / n) if top_openers and n else 0.0
+
+        # Vocabulary fingerprint (doc frequency, stopwords removed)
+        df = Counter()
+        for toks in token_lists:
+            df.update({w for w in toks if w not in STOPWORDS and len(w) > 3})
+        top_vocab = df.most_common(50)
+
+        # Phrase tells
+        tells = {}
+        for phrase in PHRASE_TELLS:
+            count = sum(t.lower().count(phrase) for t in texts)
+            tells[phrase] = {"total": count, "per_prompt": round(count / n, 3) if n else 0}
+        tell_rate = tells["as if"]["per_prompt"]
+
+        # Exact dups
+        hashes = Counter(hashlib.sha256(t.encode()).hexdigest() for t in texts)
+        exact_dups = sum(c - 1 for c in hashes.values() if c > 1)
+
+        # Near dups (sampled pairwise 5-gram Jaccard)
+        sample = token_lists[:near_dup_sample]
+        sh = [shingles(toks) for toks in sample]
+        near = sum(
+            1 for i, j in combinations(range(len(sh)), 2) if jaccard(sh[i], sh[j]) > 0.7
+        )
+        pairs = len(sh) * (len(sh) - 1) // 2
+        near_rate = round(near / pairs, 4) if pairs else 0.0
+
+        # Register distribution (post-Phase-1 only)
+        registers = Counter(
+            p.get("register") for p in items if p.get("register")
+        )
+        reg_stats = None
+        if registers:
+            total_reg = sum(registers.values())
+            reg_stats = {
+                "distinct": len(registers),
+                "per_100": round(len(registers) * 100 / min(total_reg, 100), 1),
+                "max_share": round(registers.most_common(1)[0][1] / total_reg, 3),
+                "distribution": dict(registers.most_common()),
+            }
+
+        out["modalities"][mod] = {
+            "count": n,
+            "word_count": {
+                "mean": round(sum(lengths) / n, 1) if n else 0,
+                "min": min(lengths) if lengths else 0,
+                "max": max(lengths) if lengths else 0,
+                "histogram": {k: hist.get(k, 0) for k in ["<40", "40-79", "80-119", "120-159", "160+"]},
+            },
+            "openers": {
+                "top10": [{"trigram": t, "count": c, "share": round(c / n, 3)} for t, c in top_openers],
+                "max_share": round(max_opener_share, 3),
+            },
+            "top_vocab": top_vocab[:25],
+            "phrase_tells": tells,
+            "as_if_rate": tell_rate,
+            "exact_dups": exact_dups,
+            "near_dup_rate_sampled": near_rate,
+            "registers": reg_stats,
+        }
+    return out
+
+
+def check_thresholds(report: dict) -> list[str]:
+    violations = []
+    for mod, m in report["modalities"].items():
+        if m["count"] < 30:
+            continue  # too few to judge
+        if m["openers"]["max_share"] > THRESHOLDS["max_opener_trigram_share"]:
+            violations.append(
+                f"{mod}: opener trigram share {m['openers']['max_share']} > {THRESHOLDS['max_opener_trigram_share']}"
+            )
+        if m["as_if_rate"] > THRESHOLDS["max_phrase_tell_rate"]:
+            violations.append(
+                f"{mod}: 'as if' rate {m['as_if_rate']} > {THRESHOLDS['max_phrase_tell_rate']}"
+            )
+        if m["near_dup_rate_sampled"] > THRESHOLDS["max_near_dup_rate"]:
+            violations.append(
+                f"{mod}: near-dup rate {m['near_dup_rate_sampled']} > {THRESHOLDS['max_near_dup_rate']}"
+            )
+        reg = m.get("registers")
+        if reg:
+            if reg["max_share"] > THRESHOLDS["max_register_share"]:
+                violations.append(
+                    f"{mod}: register share {reg['max_share']} > {THRESHOLDS['max_register_share']}"
+                )
+            if reg["distinct"] < THRESHOLDS["min_registers_per_100"] and m["count"] >= 100:
+                violations.append(
+                    f"{mod}: only {reg['distinct']} distinct registers (< {THRESHOLDS['min_registers_per_100']})"
+                )
+    return violations
+
+
+def print_human(report: dict) -> None:
+    print(f"PROMPT DIVERSITY REPORT — {report['total']} prompts")
+    print("=" * 70)
+    for mod, m in report["modalities"].items():
+        print(f"\n[{mod.upper()}] n={m['count']}")
+        wc = m["word_count"]
+        print(f"  words: mean={wc['mean']} min={wc['min']} max={wc['max']}")
+        print(f"  histogram: {wc['histogram']}")
+        print(f"  top openers (max share {m['openers']['max_share']}):")
+        for o in m["openers"]["top10"][:5]:
+            print(f"    {o['share']:>6.1%}  '{o['trigram']}' ({o['count']})")
+        print(f"  phrase tells (per prompt):")
+        for k, v in m["phrase_tells"].items():
+            if v["total"]:
+                print(f"    {v['per_prompt']:>6.2f}  {k!r}")
+        print(f"  exact dups: {m['exact_dups']}  near-dup rate (sampled): {m['near_dup_rate_sampled']}")
+        if m.get("registers"):
+            r = m["registers"]
+            print(f"  registers: {r['distinct']} distinct, max share {r['max_share']}")
+            for name, c in list(r["distribution"].items())[:8]:
+                print(f"    {c:>5}  {name}")
+        else:
+            print("  registers: (no register column / pre-Phase-1 data)")
+        print(f"  top vocab: {', '.join(w for w, _ in m['top_vocab'][:15])}")
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--db", required=True, type=Path)
+    ap.add_argument("--json", action="store_true", help="emit JSON instead of text")
+    ap.add_argument("--check", action="store_true", help="exit 1 if thresholds violated")
+    args = ap.parse_args()
+
+    if not args.db.expanduser().exists():
+        print(f"DB not found: {args.db}", file=sys.stderr)
+        return 2
+
+    prompts = load_prompts(args.db.expanduser())
+    if not prompts:
+        print("No prompts in DB.", file=sys.stderr)
+        return 2
+
+    report = analyze(prompts)
+    violations = check_thresholds(report)
+    report["violations"] = violations
+
+    if args.json:
+        print(json.dumps(report, indent=2, default=str))
+    else:
+        print_human(report)
+        if violations:
+            print("\nTHRESHOLD VIOLATIONS:")
+            for v in violations:
+                print(f"  ✗ {v}")
+
+    if args.check and violations:
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_diversity_thresholds.py
+++ b/tests/test_diversity_thresholds.py
@@ -1,0 +1,78 @@
+"""Threshold canary tests for the prompt diversity report (Phase 4).
+
+Marked slow-adjacent but actually fast: builds tiny fixture DBs in tmp_path.
+Verifies the --check mode catches monoculture and passes diverse data.
+"""
+
+import sqlite3
+import subprocess
+import sys
+import time
+import uuid
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[1]
+SCRIPT = REPO / "scripts" / "prompt_diversity_report.py"
+
+
+def _make_db(path: Path, prompts: list[str]) -> None:
+    conn = sqlite3.connect(str(path))
+    conn.execute(
+        """CREATE TABLE prompts (
+            id TEXT PRIMARY KEY, content TEXT NOT NULL,
+            content_type TEXT NOT NULL, modality TEXT,
+            created_at REAL NOT NULL, used_count INTEGER DEFAULT 0,
+            last_used REAL, source_media_id TEXT)"""
+    )
+    now = time.time()
+    for i, p in enumerate(prompts):
+        conn.execute(
+            "INSERT INTO prompts VALUES (?,?,?,?,?,0,NULL,NULL)",
+            (str(uuid.uuid4()), p, "prompt", "video", now - i),
+        )
+    conn.commit()
+    conn.close()
+
+
+def _run_check(db: Path) -> int:
+    proc = subprocess.run(
+        [sys.executable, str(SCRIPT), "--db", str(db), "--check"],
+        capture_output=True,
+        text=True,
+    )
+    return proc.returncode
+
+
+def test_monoculture_fails_check(tmp_path):
+    base = (
+        "A tight close-up frames the subject as if holding a breath, "
+        "monochrome light over charcoal shadows while the camera stays "
+        "locked and nothing moves but a faint tremor of stillness"
+    )
+    prompts = [base + f" take {i}." for i in range(40)]
+    db = tmp_path / "mono.db"
+    _make_db(db, prompts)
+    assert _run_check(db) == 1
+
+
+def test_diverse_passes_check(tmp_path):
+    import random
+
+    rng = random.Random(7)
+    subjects = ["a forklift driver", "two kids", "a vendor", "a stray dog",
+                "a barista", "a traffic cop", "an old fisherman", "a courier"]
+    verbs = ["stacks crates", "cross the street", "arranges fruit", "trots past",
+             "steams milk", "waves cars on", "mends a net", "locks a bike"]
+    places = ["in a warehouse", "at a crosswalk", "at a night market",
+              "near the harbor", "in a cafe", "downtown", "on a pier", "by a wall"]
+    tails = ["rain hits the lens", "a bus passes", "a door slams", "wind lifts dust",
+             "someone enters frame", "the light turns green", "gulls scatter",
+             "a phone buzzes"]
+    prompts = []
+    for i in range(60):
+        parts = [rng.choice(subjects), rng.choice(verbs), rng.choice(places) + ",",
+                 rng.choice(tails) + ","] + rng.sample(tails, k=rng.randint(1, 3))
+        prompts.append((" ".join(parts)).capitalize() + f" clip {i}.")
+    db = tmp_path / "diverse.db"
+    _make_db(db, prompts)
+    assert _run_check(db) == 0

--- a/tests/test_prompt_generator_spec.py
+++ b/tests/test_prompt_generator_spec.py
@@ -1,0 +1,73 @@
+"""Tests for PromptSpec injection into PromptGenerator message building.
+
+GPU-free: only exercises the static message-construction path.
+"""
+
+from collections import deque
+
+from gas.generation.prompts.prompt_generator import PromptGenerator
+from gas.generation.prompts.register_sampler import sample_spec
+from gas.generation.prompts.scene import SceneDescription
+
+
+def _scene():
+    return SceneDescription(
+        caption="A man sits at a desk near a window.",
+        subject="man at desk",
+        setting="home office",
+        dynamic_candidates=["curtains", "dust motes"],
+    )
+
+
+def test_user_message_carries_committed_spec():
+    spec = sample_spec(modality="video", rng_seed=3)
+    msg = PromptGenerator._build_user_message(
+        _scene(), deque(), "", spec=spec
+    )
+    assert "COMMITTED SHOT SPEC" in msg
+    assert spec.register in msg
+    assert str(spec.length_words[0]) in msg and str(spec.length_words[1]) in msg
+
+
+def test_video_spec_includes_camera_and_events():
+    spec = sample_spec(modality="video", rng_seed=3)
+    msg = PromptGenerator._build_user_message(_scene(), deque(), "", spec=spec)
+    assert spec.camera_motion in msg
+    if spec.event_count > 0:
+        assert "discrete event" in msg
+    else:
+        assert "ambient motion only" in msg
+
+
+def test_plain_register_bans_rendered():
+    # find a seed yielding a plain register
+    spec = None
+    for seed in range(100):
+        s = sample_spec(modality="video", rng_seed=seed)
+        if s.style_strictness == "plain":
+            spec = s
+            break
+    assert spec is not None
+    msg = PromptGenerator._build_user_message(_scene(), deque(), "", spec=spec)
+    assert "Forbidden" in msg
+    assert "as if" in msg
+
+
+def test_no_spec_is_backward_compatible():
+    msg = PromptGenerator._build_user_message(_scene(), deque(), "100-180 words")
+    assert "COMMITTED SHOT SPEC" not in msg
+    assert "100-180 words" in msg
+
+
+def test_plausible_events_listed_when_present():
+    scene = _scene()
+    scene.plausible_events = ["a courier knocks", "the desk lamp flickers"]
+    spec = None
+    for seed in range(200):
+        s = sample_spec(modality="video", rng_seed=seed)
+        if s.event_count > 0:
+            spec = s
+            break
+    assert spec is not None
+    msg = PromptGenerator._build_user_message(scene, deque(), "", spec=spec)
+    assert "a courier knocks" in msg

--- a/tests/test_prompt_qc.py
+++ b/tests/test_prompt_qc.py
@@ -1,0 +1,88 @@
+"""Tests for the prompt QC gate."""
+
+from gas.generation.prompts.prompt_qc import validate
+from gas.generation.prompts.register_sampler import sample_spec
+
+
+def _plain_spec():
+    for seed in range(200):
+        s = sample_spec(modality="video", rng_seed=seed)
+        if s.style_strictness == "plain" and s.length_band == "medium":
+            return s
+    raise AssertionError("no plain/medium spec found")
+
+
+def _free_spec():
+    for seed in range(200):
+        s = sample_spec(modality="video", rng_seed=seed)
+        if s.style_strictness == "free" and s.length_band == "medium":
+            return s
+    raise AssertionError("no free/medium spec found")
+
+
+def _words(n):
+    return " ".join(f"word{i}" for i in range(n))
+
+
+def test_accepts_clean_prompt_in_band():
+    spec = _free_spec()
+    lo, hi = spec.length_words
+    text = "A man crosses a rainy street while " + _words(lo)
+    ok, reason = validate(text, spec)
+    assert ok, reason
+
+
+def test_rejects_meta_text():
+    spec = _free_spec()
+    lo, _ = spec.length_words
+    for bad in ("Here is a prompt: ", "COMMITTED SHOT SPEC ", "As an AI "):
+        ok, reason = validate(bad + _words(lo + 5), spec)
+        assert not ok
+        assert "meta" in reason
+
+
+def test_rejects_structural_markup():
+    spec = _free_spec()
+    lo, _ = spec.length_words
+    ok, reason = validate("- bullet one\n- bullet two " + _words(lo), spec)
+    assert not ok
+
+
+def test_rejects_out_of_band_length():
+    spec = _free_spec()
+    lo, hi = spec.length_words
+    ok, reason = validate(_words(int(hi * 1.4)), spec)
+    assert not ok and "length" in reason
+    ok, reason = validate(_words(max(3, int(lo * 0.5))), spec)
+    assert not ok and "length" in reason
+
+
+def test_band_tolerance():
+    spec = _free_spec()
+    lo, hi = spec.length_words
+    # 10% over the ceiling is within the +-20% tolerance
+    ok, reason = validate(_words(int(hi * 1.1)), spec)
+    assert ok, reason
+
+
+def test_plain_register_bans_enforced():
+    spec = _plain_spec()
+    lo, _ = spec.length_words
+    text = "The hallway sits empty as if holding its breath " + _words(lo)
+    ok, reason = validate(text, spec)
+    assert not ok and "banned" in reason
+
+
+def test_free_register_allows_literary_style():
+    spec = _free_spec()
+    lo, _ = spec.length_words
+    text = "The hallway sits empty as if holding its breath " + _words(lo)
+    ok, reason = validate(text, spec)
+    assert ok, reason
+
+
+def test_no_spec_minimal_checks():
+    ok, reason = validate("A short but valid plain prompt about a dog. " + _words(30), None)
+    assert ok
+    ok, reason = validate("Here is a prompt: " + _words(30), None)
+    assert not ok

--- a/tests/test_prompt_store_dedup.py
+++ b/tests/test_prompt_store_dedup.py
@@ -1,0 +1,56 @@
+"""Tests for near-duplicate rejection at prompt write time."""
+
+import pytest
+
+from gas.cache.db.connection import ConnectionManager, create_schema
+from gas.cache.db.prompt_store import PromptStore
+
+
+@pytest.fixture()
+def store(tmp_path):
+    db = ConnectionManager(tmp_path / "prompts.db")
+    with db.connect() as conn:
+        create_schema(conn)
+    return PromptStore(db)
+
+
+BASE = (
+    "A cyclist pedals along a wet boardwalk at dawn, gulls scattering ahead "
+    "of the front wheel while heavy clouds drift over the bay and the first "
+    "joggers pass in the opposite direction wearing bright windbreakers."
+)
+
+
+def test_distinct_prompt_accepted(store):
+    a = store.add_prompt_entry(content=BASE, modality="video")
+    b = store.add_prompt_entry(
+        content=(
+            "Inside a cluttered workshop a luthier planes the top of an "
+            "unfinished guitar, shavings curling onto the bench as dust "
+            "hangs in the light from a single window."
+        ),
+        modality="video",
+    )
+    assert a is not None and b is not None and a != b
+
+
+def test_near_duplicate_rejected(store):
+    a = store.add_prompt_entry(content=BASE, modality="video")
+    assert a is not None
+    # Paraphrase-level duplicate: only a few words changed.
+    near = BASE.replace("dawn", "first light").replace("heavy", "low")
+    b = store.add_prompt_entry(content=near, modality="video")
+    assert b is None
+
+
+def test_near_duplicate_other_modality_allowed(store):
+    a = store.add_prompt_entry(content=BASE, modality="video")
+    near = BASE.replace("dawn", "first light")
+    b = store.add_prompt_entry(content=near, modality="image")
+    assert a is not None and b is not None
+
+
+def test_exact_duplicate_returns_existing_id(store):
+    a = store.add_prompt_entry(content=BASE, modality="video")
+    b = store.add_prompt_entry(content=BASE, modality="video")
+    assert a == b

--- a/tests/test_prompt_store_spec.py
+++ b/tests/test_prompt_store_spec.py
@@ -1,0 +1,56 @@
+"""Tests for prompt spec persistence (schema migration + write path)."""
+
+import json
+import sqlite3
+
+import pytest
+
+from gas.cache.db.connection import ConnectionManager, create_schema
+from gas.cache.db.prompt_store import PromptStore
+
+
+@pytest.fixture()
+def store(tmp_path):
+    db = ConnectionManager(tmp_path / "prompts.db")
+    with db.connect() as conn:
+        create_schema(conn)
+    return PromptStore(db)
+
+
+def test_spec_columns_exist(store):
+    with store.db.connect() as conn:
+        cols = {r[1] for r in conn.execute("PRAGMA table_info(prompts)")}
+    for col in ("register", "length_band", "event_count", "scene_json", "spec_json"):
+        assert col in cols, f"missing column {col}"
+
+
+def test_write_with_spec_fields(store):
+    pid = store.add_prompt_entry(
+        content="A man waits at a bus stop in light rain.",
+        modality="video",
+        register="phone_casual",
+        length_band="short",
+        event_count=1,
+        scene_json=json.dumps({"subject": "man"}),
+        spec_json=json.dumps({"register": "phone_casual"}),
+    )
+    with store.db.connect() as conn:
+        row = conn.execute(
+            "SELECT register, length_band, event_count, scene_json, spec_json "
+            "FROM prompts WHERE id = ?",
+            (pid,),
+        ).fetchone()
+    assert row[0] == "phone_casual"
+    assert row[1] == "short"
+    assert row[2] == 1
+    assert json.loads(row[3])["subject"] == "man"
+    assert json.loads(row[4])["register"] == "phone_casual"
+
+
+def test_write_without_spec_fields_back_compat(store):
+    pid = store.add_prompt_entry(content="A dog runs on a beach.", modality="image")
+    with store.db.connect() as conn:
+        row = conn.execute(
+            "SELECT register, spec_json FROM prompts WHERE id = ?", (pid,)
+        ).fetchone()
+    assert row[0] is None and row[1] is None

--- a/tests/test_register_sampler.py
+++ b/tests/test_register_sampler.py
@@ -1,0 +1,75 @@
+"""Tests for gas.generation.prompts.register_sampler."""
+
+from gas.generation.prompts.register_sampler import (
+    REGISTERS,
+    PromptSpec,
+    sample_spec,
+)
+
+
+def test_sample_spec_fields():
+    spec = sample_spec(modality="video", rng_seed=7)
+    assert spec.register in {r.name for r in REGISTERS}
+    assert spec.length_band in {"short", "medium", "long"}
+    assert spec.event_count in (0, 1, 2)
+    assert isinstance(spec.camera_motion, str) and spec.camera_motion
+    assert spec.length_words[0] < spec.length_words[1]
+    assert spec.style_strictness in {"plain", "free"}
+
+
+def test_deterministic_with_seed():
+    a = sample_spec(modality="video", rng_seed=42)
+    b = sample_spec(modality="video", rng_seed=42)
+    assert a == b
+
+
+def test_distribution_not_degenerate():
+    specs = [sample_spec(modality="video", rng_seed=i) for i in range(300)]
+    regs = {s.register for s in specs}
+    assert len(regs) >= 8, f"only {len(regs)} registers in 300 draws"
+    shorts = sum(s.length_band == "short" for s in specs)
+    assert shorts > 30, f"only {shorts} short prompts in 300 draws"
+    no_event = sum(s.event_count == 0 for s in specs)
+    assert 0 < no_event < 300
+
+
+def test_image_modality_has_no_events_or_camera_motion():
+    spec = sample_spec(modality="image", rng_seed=5)
+    assert spec.event_count == 0
+    assert spec.camera_motion == ""
+
+
+def test_cctv_always_static():
+    static_specs = [
+        s for s in (sample_spec(modality="video", rng_seed=i) for i in range(500))
+        if s.register == "cctv_surveillance"
+    ]
+    assert static_specs, "cctv never sampled in 500 draws"
+    assert all(s.camera_motion == "static" for s in static_specs)
+
+
+def test_plain_registers_have_banned_phrases():
+    specs = [sample_spec(modality="video", rng_seed=i) for i in range(200)]
+    plains = [s for s in specs if s.style_strictness == "plain"]
+    assert plains
+    assert all(s.banned_phrases for s in plains)
+
+
+def test_weights_override():
+    specs = [
+        sample_spec(
+            modality="video",
+            rng_seed=i,
+            weights_override={"dashcam": 1.0},
+        )
+        for i in range(50)
+    ]
+    assert all(s.register == "dashcam" for s in specs)
+
+
+def test_to_dict_roundtrip_json():
+    import json
+
+    spec = sample_spec(modality="video", rng_seed=1)
+    blob = json.dumps(spec.to_dict())
+    assert json.loads(blob)["register"] == spec.register

--- a/tests/test_scene_remix.py
+++ b/tests/test_scene_remix.py
@@ -1,0 +1,78 @@
+"""Tests for scene remixing (semi-synthetic scene generation)."""
+
+import random
+
+import pytest
+
+from gas.generation.prompts.scene import SceneDescription
+from gas.generation.prompts.scene_remix import remix
+
+
+def _scene():
+    return SceneDescription(
+        caption="A fisherman repairs a net on a wooden dock at golden hour.",
+        subject="fisherman repairing net",
+        scene_kind="documentary",
+        setting="wooden dock",
+        environment_type="outdoor",
+        time_of_day="golden hour",
+        weather="clear",
+        lighting="warm low sun",
+        color_palette="amber and teal",
+        dynamic_candidates=["water", "net", "gulls"],
+        plausible_events=["a gull lands on a post"],
+    )
+
+
+SETTING_POOL = ["night market alley", "hospital waiting room", "alpine trailhead"]
+
+
+def test_remix_changes_one_to_three_fields():
+    rng = random.Random(0)
+    original = _scene()
+    remixed = remix(original, rng, setting_pool=SETTING_POOL)
+    mutable = ("time_of_day", "weather", "setting", "environment_type", "mood")
+    changed = [f for f in mutable if getattr(remixed, f) != getattr(original, f)]
+    assert 1 <= len(changed) <= 3
+
+
+def test_subject_preserved():
+    rng = random.Random(1)
+    remixed = remix(_scene(), rng, setting_pool=SETTING_POOL)
+    assert remixed.subject == "fisherman repairing net"
+
+
+def test_caption_replaced_with_stub():
+    rng = random.Random(2)
+    original = _scene()
+    remixed = remix(original, rng, setting_pool=SETTING_POOL)
+    assert remixed.caption != original.caption
+    assert "fisherman repairing net" in remixed.caption
+
+
+def test_lighting_cleared_when_time_changes():
+    found = False
+    for seed in range(100):
+        rng = random.Random(seed)
+        original = _scene()
+        remixed = remix(original, rng, setting_pool=SETTING_POOL)
+        if remixed.time_of_day != original.time_of_day:
+            assert remixed.lighting == ""
+            assert remixed.color_palette == ""
+            found = True
+            break
+    assert found, "time_of_day never changed in 100 seeds"
+
+
+def test_original_not_mutated():
+    rng = random.Random(3)
+    original = _scene()
+    before = original.to_dict()
+    remix(original, rng, setting_pool=SETTING_POOL)
+    assert original.to_dict() == before
+
+
+def test_works_without_setting_pool():
+    rng = random.Random(4)
+    remixed = remix(_scene(), rng)
+    assert remixed.subject == "fisherman repairing net"


### PR DESCRIPTION
## Summary

Gasstation prompts had collapsed into a single format: every video prompt was a locked-off, shallow-DoF close-up in the same literary voice (negation litanies, "as if" similes, closing aphorisms), all riding the 180-word ceiling, with only ambient micro-motion and zero discrete events. Root cause: the composer LLM was being used as a diversity *source* when it is only safe as a diversity *renderer* — left to pick register/structure/length/style itself, it samples its own collapsed prior.

This PR moves every diversity-bearing decision out of the LLM into explicitly sampled, persisted, auditable structure:

- **Register sampler** (`gas/generation/prompts/register_sampler.py`): 12 weighted registers (phone casual/vertical, CCTV, dashcam, home video, news broadcast, documentary, drone, screen recording, 3D animation, webcam, polished cinema) with per-register camera motions, length bands (short 25% / medium 45% / long 30%), an event budget (0/1/2 discrete events), and banned-phrase lists for plain registers. `weights_override` is the hook for a future discriminator-feedback loop.
- **Committed shot spec injection**: `_compose`/`_build_user_message` receive a sampled `PromptSpec` and render it as an authoritative `COMMITTED SHOT SPEC` block; system prompts updated so the LLM only realizes the committed axes. Length budget and `max_new_tokens` follow the sampled band.
- **Event grounding**: VLM schema + `SceneDescription` gain `plausible_events` (2-4 discrete events grounded in the pixels) so video prompts can contain things *happening*, not just hair drifting.
- **Spec persistence**: migration `add_prompt_spec_columns` adds `register`, `length_band`, `event_count`, `scene_json`, `spec_json` to `prompts`; the generator service samples one spec per scene per modality and stores it with every prompt — diversity becomes measurable instead of anecdotal.
- **QC gate** (`prompt_qc.py`): rejects meta-text, structural markup, out-of-band length (±20%), and banned phrases in plain registers; one retry with the rejection reason, then drop.
- **Near-dup guard**: 5-gram Jaccard (>0.45) against the last 200 same-modality prompts at write time; paraphrase-level repeats return `None` and are counted/logged.
- **Scene remix** (`scene_remix.py`): ~25% of each batch is a real VLM scene with 1-3 contextual fields resampled (subject preserved, lighting/palette cleared when time-of-day changes, caption stubbed) — breaks scraper-distribution inheritance while keeping real-scene correlational texture. Settings pool drawn from the DB's own recent `scene_json`.
- **Diversity report + canary** (`scripts/prompt_diversity_report.py`): opener-trigram share, length histogram, phrase tells, near-dup rate, register distribution; `--check` exits nonzero on threshold violations (suitable for cron/CI).

Measured on a fixture seeded with recent production prompts, the report quantifies the baseline collapse: **87.5% opener-trigram share, 0.71 "as if" per prompt, 1.0 "close-up" per prompt**.

## Test Plan

- [x] 37 tests pass (`pytest tests/ -q`), all new modules TDD'd (register sampler, spec injection, persistence, QC, dedup, remix, canary)
- [x] Canary verified both ways: monoculture fixture exits 1, diverse fixture exits 0
- [x] Migration is additive (nullable columns) via the existing `_schema_migrations` system; old DBs and old call sites unaffected
- [X] GPU smoke test on a validator host: run a prompt-gen batch, grep `[PROMPT-GEN]`, eyeball ~20 outputs for register compliance
- [X] Before/after diversity report on the live `~/.cache/sn34/prompts.db`

## Notes for reviewers

- Canonical-prompt contract to miners is unchanged; `adapt_for_local_model` untouched.
- QC retry means occasional double LLM calls per prompt (rejection-only); twice-failed prompts are dropped, so batch counts can dip slightly.
- `NEAR_DUP_JACCARD = 0.45` is the most tunable constant — two word substitutions in a 35-word prompt score ~0.5, distinct prompts score near 0. Watch the skip counter in the first live batches.
- README says contribute against `testnet`, but no `testnet` ref exists on origin — based on `main`; happy to retarget.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches validator prompt cache population, generative challenge assignment, and reward score zeroing; batch sizes may dip from QC/dedup but miner-facing prompt text contract is unchanged.
> 
> **Overview**
> **Prompt diversity** moves register, length, camera, and event choices out of the composer LLM into a weighted **`PromptSpec` sampler** (`register_sampler.py`), injected as an authoritative **COMMITTED SHOT SPEC** in `PromptGenerator` with **QC** (`prompt_qc.py`, one retry) and **token budgets** tied to sampled length bands. VLM scenes gain **`plausible_events`**; ~**25%** of batches add **scene remix** (`scene_remix.py`) with settings drawn from recent `scene_json`.
> 
> **Persistence and cache quality:** migration adds **`register` / `length_band` / `event_count` / `scene_json` / `spec_json`** on `prompts`; `generator_service` writes them and counts **near-duplicate** rejects (5-gram Jaccard). **`write_prompt`** can return **`None`** when rejected.
> 
> **Challenges:** `GenerativeChallengeManager` pre-samples per-modality prompt pools and assigns a **random modality per miner** (only modalities with prompts), instead of one modality for the whole round.
> 
> **Ops / scoring:** `scripts/prompt_diversity_report.py` (+ tests) for concentration metrics and **`--check`** thresholds; validator generator **liveness cutoff** uses **`last_seen` timestamps** vs a time window, not mere dict presence. Generator loop runs **verification** once before the first prompt batch.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8671d55882c9a1434b49b2a928d0600002efe44f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->