### PR TITLE
feat: rebalance video challenge tier mix (40/40/20)

### DIFF
--- a/gas/evaluation/resolution_tiers.py
+++ b/gas/evaluation/resolution_tiers.py
@@ -39,9 +39,9 @@ _TIER_RANK: Dict[str, Dict[str, int]] = {
 # probed (top tiers are the most expensive for miners to serve).
 CHALLENGE_TIER_WEIGHTS: Dict[str, Dict[str, float]] = {
     VIDEO_MODALITY: {
-        "480p": 0.20,
+        "480p": 0.40,
         "720p": 0.40,
-        "1080p": 0.40,
+        "1080p": 0.20,
     },
     IMAGE_MODALITY: {
         "1K": 0.40,


### PR DESCRIPTION
## Change

Video challenge tier sampling rebalanced from 480p 20% / 720p 40% / 1080p 40% to **480p 40% / 720p 40% / 1080p 20%**. Image mix unchanged (1K 40 / 2K 40 / 4K 20 — same shape).

## Rationale

- 1080p is the most expensive tier for miners (4-5x the per-clip cost of 480p) while CLIP verification and detector inputs run at modest resolutions — extra 1080p share is the priciest way to grow the dataset. 20% keeps the premium capability probe (and its 3.65-4.0x multipliers) meaningful without dominating spend.
- 480p is deliberately oversampled: compression-degraded synthetic video is the documented weak spot of deepfake detectors, and it is the cheapest training data to acquire.
- Expected miner cost per Seedance-full challenge: ~$1.86 -> ~$1.48; expected multiplier 3.43 -> 3.06.

One-table change in `resolution_tiers.py`; all validators share the hardcoded mix so expected miner cost stays uniform across the network.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single constant-table tweak for challenge sampling; no auth, security, or pricing logic changes beyond shifted request frequencies.
> 
> **Overview**
> **Rebalances how often validators request each video resolution tier** by updating `CHALLENGE_TIER_WEIGHTS` in `resolution_tiers.py`: **480p** rises from 20% to **40%**, **720p** stays **40%**, and **1080p** drops from 40% to **20%**. Image tier weights are unchanged.
> 
> Every validator uses this shared table via `sample_challenge_tier`, so the network-wide challenge mix and expected miner cost per challenge shift toward cheaper 480p and away from costly 1080p without changing classification or reward math.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b01f8943fe0aac3e6d14d33a6f196880db65e6c1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->