### PR TITLE
tune: double generator challenge frequency

### DIFF
--- a/gas/config.py
+++ b/gas/config.py
@@ -203,7 +203,7 @@ def add_validator_args(parser):
         "--generator-challenge-interval",
         type=int,
         help="How often we send challenges to generative miners, measured in 12 second blocks.",
-        default=220,
+        default=110,
     )
 
     parser.add_argument(


### PR DESCRIPTION
## Summary

- reduce the default generator challenge interval from 220 blocks to 110 blocks
- double the generator request cadence without changing validator CLI override behavior

## Motivation

We have observed an increase in generator miner registrations. Increasing the request frequency gives the larger generator pool more frequent evaluation coverage and fresher reward data.

## Scope

This is intentionally a one-line configuration change. It does not bump the release version.