### PR TITLE
docs: align discriminator taxonomy and scoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ GAS runs two parallel competition tracks on Bittensor Subnet 34:
 
 | Track | What You Do | How You're Scored |
 |-------|-------------|-------------------|
-| **Discriminative Mining** | Submit AI-generated content detection models (image, video, audio) | `sn34_score` -- geometric mean of MCC and Brier score, measuring both accuracy and calibration |
+| **Discriminative Mining** | Submit media-provenance classifiers (image, video, audio) | `sn34_score` -- geometric mean of normalized MCC and Brier performance, using the active round's binary or multiclass scoring mode |
 | **Generative Mining** | Run a server that generates synthetic media on demand | Base reward for valid content × multiplier for fooling discriminators |
 
 **Key facts:**

--- a/docs/Discriminative-Mining.md
+++ b/docs/Discriminative-Mining.md
@@ -6,10 +6,20 @@ Follow the [Installation Guide](Installation.md) to set up your environment befo
 
 ## Discriminative Mining Overview
 
-- Miners submit binary classifiers that distinguish genuine content from AI-generated or AI-manipulated content across three modalities: **image**, **video**, and **audio**.
-- For each evaluation sample, a model receives a media input and must produce a binary prediction $[p_{\text{real}}, p_{\text{synthetic}}]$ -- a probability distribution over two classes.
-- Some datasets contain semisynthetic content (e.g., inpainting, faceswaps). For scoring purposes, semisynthetic is treated as `synthetic`.
+- Miners submit media-provenance classifiers across three modalities: **image**, **video**, and **audio**.
+- Image models classify `[real, synthetic, semisynthetic]`; video models classify `[real, synthetic, semisynthetic, rendered]`; audio remains `[real, synthetic]`.
+- The visual taxonomy is experimental. Semisynthetic media retains materially captured visual content alongside spatially localized generated or replaced content. Fully synthesized output remains synthetic even when captured media conditions generation.
 - Models are evaluated on cloud infrastructure -- miners do not need to host hardware for inference.
+
+Class order is part of the submission contract:
+
+| Modality | `num_classes` | Logit indices |
+| --- | ---: | --- |
+| Image | 3 | `0=real`, `1=synthetic`, `2=semisynthetic` |
+| Video | 4 | `0=real`, `1=synthetic`, `2=semisynthetic`, `3=rendered` |
+| Audio | 2 | `0=real`, `1=synthetic` |
+
+See GASBench's [Classification Taxonomy and Scoring](https://github.com/BitMind-AI/gasbench/blob/main/docs/Classification-and-Scoring.md) for the normative class definitions, metric formulas, and binary compatibility collapse.
 
 ## Model Preparation
 
@@ -85,11 +95,11 @@ At least one model (image, video, or audio) must be provided.
 
 ### Scoring
 
-Each model is scored per modality using the `sn34_score`, a geometric mean of normalized MCC and Brier score:
+Each model is scored per modality using `sn34_score`, a geometric mean of normalized MCC and Brier performance:
 
-$$sn34_{score} = \sqrt{MCC_{norm}^{\alpha} \cdot Brier_{norm}^{\beta}}$$
+$$sn34_{score} = \sqrt{M_{norm} \cdot B_{norm}}$$
 
-Where $\alpha = 1.2$ and $\beta = 1.8$. This rewards both discrimination accuracy (MCC) and calibration quality (Brier). See [Incentive Mechanism](Incentive.md) for the full formula.
+The normalized terms apply exponents $1.2$ to MCC performance and $1.8$ to Brier performance. Image and video currently use multiclass Gorodkin MCC and multiclass Brier, rewarding correct distinctions between provenance classes. Audio uses the equivalent two-class calculation. Binary real-versus-not-real metrics are still reported for compatibility and diagnosis. See [Incentive Mechanism](Incentive.md) for the full formula.
 
 ### Model Requirements
 
@@ -184,7 +194,7 @@ Models that pass the entrance exam are benchmarked against the **complete datase
 - **Private holdout datasets** — curated datasets not visible to miners, used to prevent overfitting to the public benchmark set
 - Refreshed weekly with new data from the GAS-Station pipeline
 
-The full benchmark has a **maximum wall-clock timeout of 5 hours** (18,000 seconds) per modality. The benchmark score from this stage determines your **TAO emissions** on Subnet 34. Scores are computed using the `sn34_score` formula (see [Incentive Mechanism](Incentive.md)).
+The full benchmark has a **maximum wall-clock timeout of 5 hours** (18,000 seconds) per modality. The benchmark score from this stage determines your **TAO emissions** on Subnet 34. The active round configuration selects provenance weighting, multiclass scoring, and augmentation robustness parameters; see [Incentive Mechanism](Incentive.md).
 
 You can simulate a full benchmark run locally (without holdouts) to get a sense of your model's performance:
 
@@ -210,7 +220,7 @@ gascli d perf --modality image --vertical human
 gascli d perf --wallet-name miner1 --wallet-hotkey default
 ```
 
-Each row shows the run ID, status (`queued`/`running`/`success`/`failed`), modality, vertical, SN34 score, MCC, and Brier score.
+Each row shows the run ID, status (`queued`/`running`/`success`/`failed`), modality, vertical, SN34 score, MCC, and Brier score. The displayed MCC and Brier fields may be the binary compatibility metrics; `sn34_score` remains the authoritative competition score selected by the round configuration.
 
 ### Getting Help
 

--- a/docs/Incentive.md
+++ b/docs/Incentive.md
@@ -3,12 +3,12 @@
 ## Benchmark Runs
 Submitted discriminator miners are evaluated against a subset of the data sources listed below. Models are evaluated on cloud infrastructure -- miners do not need to host hardware for inference. A portion of the evaluation data comes from generative miners, who are rewarded based on their ability to submit data that both pass validator sanity checks (prompt alignment, etc.) and fool discriminators in benchmark runs.
 
-Each modality (image, video, audio) is scored independently using the `sn34_score` metric, which combines discrimination accuracy (MCC) with calibration quality (Brier score).
+Each modality (image, video, audio) is scored independently using the `sn34_score` metric, which combines classification performance (MCC) with probability calibration (Brier score). The active round selects binary or multiclass scoring per modality.
 
 <details>
 <summary><strong>Evaluation Datasets</strong></summary>
 
-Benchmark datasets are regularly expanded. Each modality includes a mix of real, synthetic, and semi-synthetic content from diverse sources (including continuously-updated [GAS-Station](https://huggingface.co/gasstation) data from generative miners).
+Benchmark datasets are regularly expanded. Image uses real, synthetic, and semisynthetic classes; video additionally includes rendered media; audio remains binary. The experimental visual taxonomy is defined in GASBench's [Classification Taxonomy and Scoring](https://github.com/BitMind-AI/gasbench/blob/main/docs/Classification-and-Scoring.md). Datasets include continuously updated [GAS-Station](https://huggingface.co/gasstation) data from generative miners.
 
 **Public datasets** (available for training via gasbench):
 - **Image**: [`image_datasets.yaml`](https://github.com/BitMind-AI/gasbench/blob/main/src/gasbench/dataset/configs/image_datasets.yaml)
@@ -111,21 +111,32 @@ This design incentivizes generators to:
 
 ### Scoring: `sn34_score`
 
-Each discriminator model is scored per modality using the `sn34_score`, which combines two metrics:
+Each discriminator model is scored per modality using two components:
 
-1. **Binary MCC (Matthews Correlation Coefficient)** -- measures how well the model discriminates between real and synthetic content. Ranges from -1 (worst) to +1 (perfect).
+1. **MCC** measures classification quality. Binary mode uses ordinary MCC after collapsing every non-real class into synthetic. Multiclass mode uses Gorodkin's $R_K$, the multiclass generalization of MCC.
+2. **Brier score** measures calibration. Binary mode uses the mean squared error of $p_{\text{not real}}$, whose constant-guess baseline is $0.25$. Multiclass mode uses the mean of $\sum_k(p_k-y_k)^2$, whose uniform-guess baseline for $K$ classes is $B_0=(K-1)/K$.
 
-2. **Brier Score** -- measures calibration quality (how well predicted probabilities match actual outcomes). Ranges from 0 (perfect) to 0.25 (random baseline).
+For the selected mode, let $M$ be MCC, $B$ be Brier score, and $B_0$ be the corresponding random baseline:
 
-These are combined as follows:
+$$M_{norm} = \operatorname{clip}\left(\frac{M+1}{2},0,1\right)^{1.2}$$
 
-$$MCC_{norm} = \left(\frac{MCC + 1}{2}\right)^{\alpha}$$
+$$B_{norm} = \max\left(0,\frac{B_0-B}{B_0}\right)^{1.8}$$
 
-$$Brier_{norm} = \left(\frac{0.25 - Brier}{0.25}\right)^{\beta}$$
+$$sn34_{score} = \sqrt{M_{norm} \cdot B_{norm}}$$
 
-$$sn34_{score} = \sqrt{MCC_{norm} \cdot Brier_{norm}}$$
+Image and video currently use multiclass scoring. Audio uses binary scoring; with two classes, the normalized multiclass calculation is mathematically identical. Every run also reports `binary_sn34_score` and `multiclass_sn34_score` so the two views can be compared.
 
-With default parameters $\alpha = 1.2$ and $\beta = 1.8$. The geometric mean penalizes models that are strong on one axis but weak on the other -- a model must be both accurate *and* well-calibrated to score highly.
+### Dataset composition and augmentation robustness
+
+The round configuration assigns target score shares to public, private holdout, and GAS-Station samples. Those shares are converted into per-sample weights and applied consistently to accuracy, MCC, Brier, cross-entropy, and the resulting SN34 score.
+
+When the robustness pass is enabled, the final score is:
+
+$$sn34_{final} = (1-w)\,sn34_{base} + w\,sn34_{aug}$$
+
+The benchmark records `base_sn34_score`, `aug_sn34_score`, and robustness diagnostics. Exact composition shares, augmentation sample counts, and $w$ are round configuration, so they may change between benchmark versions rather than being permanent protocol constants.
+
+The normative implementation details and complete metric field glossary live in GASBench's [Classification Taxonomy and Scoring](https://github.com/BitMind-AI/gasbench/blob/main/docs/Classification-and-Scoring.md).
 
 ### Competition Rounds
 

--- a/docs/ONNX.md
+++ b/docs/ONNX.md
@@ -20,9 +20,12 @@ This guide explains how to create ONNX models for discriminative mining using th
    - Gasbench handles preprocessing (shortest-edge resize, center crop, augmentations)
    - Your model wrapper should only normalize to [0, 1] and apply model-specific normalization
 
-3. **Output Format**: Return logits for 3 classes `[real, synthetic, semisynthetic]`
-   - Image models: `(batch_size, 3)`
-   - Video models: `(batch_size, 3)` after temporal aggregation
+3. **Output Format**: Historical ONNX artifacts must follow the same current class order as safetensors submissions:
+   - Image: 3 logits `[real, synthetic, semisynthetic]`
+   - Video: 4 logits `[real, synthetic, semisynthetic, rendered]` after temporal aggregation
+   - Audio: 2 logits `[real, synthetic]`
+
+This page is retained only for legacy artifact maintenance. New competition submissions must follow the [Safetensors Model Specification](https://github.com/bitmind-ai/gasbench/blob/main/docs/Safetensors.md).
 
 
 ## Example Scripts


### PR DESCRIPTION
## Summary
- update the discriminative mining guide for 3-class image, 4-class video, and binary audio outputs
- document multiclass competition scoring while retaining binary metrics as compatibility diagnostics
- explain round-configured dataset composition and augmentation robustness
- correct the deprecated ONNX guide and link to the canonical Gasbench specification

Companion to the Gasbench taxonomy and scoring documentation PR.