### PR TITLE
fix: show scoring-aligned augmented metrics in d perf

### DIFF
--- a/gas/cli.py
+++ b/gas/cli.py
@@ -645,8 +645,8 @@ def perf(wallet_name, wallet_hotkey, modality, api_url):
                     brier = r.get("brier")
                     base_sn34 = r.get("base_sn34_score")
                     aug_sn34 = r.get("aug_sn34_score")
-                    aug_mcc = r.get("aug_binary_mcc")
-                    aug_brier = r.get("aug_binary_brier")
+                    aug_mcc = r.get("aug_mcc")
+                    aug_brier = r.get("aug_brier")
 
                     bar_len = 20
                     filled = int(sn34 * bar_len)


### PR DESCRIPTION
## Summary
- read augmented MCC from aug_mcc
- read augmented Brier from aug_brier
- align gascli d perf output with the metrics used to calculate augmented SN34

## Validation
- Python compilation passed
- diff validation passed