### PR TITLE
Document validator GAS API authorization requirement

### DIFF
--- a/docs/Validating.md
+++ b/docs/Validating.md
@@ -4,6 +4,16 @@ Run the SN34 validator (validator + generator + data services). Two ways: **PM2*
 
 Prerequisites: [Installation Guide](Installation.md), Bittensor wallet, GPU for generation.
 
+## GAS API authorization
+
+Before starting, contact the BitMind team with the **public SS58 address of your validator hotkey** and request GAS API whitelist access. Subnet registration alone does not grant access. Use the hotkey selected by `WALLET_NAME` and `WALLET_HOTKEY` in `.env.validator`; those variables name local wallet files, while the whitelist stores the public address.
+
+The team adds the address through a PR to [`Settings.AUTHORIZED_VALIDATORS` in bmcore](https://github.com/BitMind-AI/bmcore/blob/main/src/apps/gas_api/config.py). The change must be merged and the Modal `gas_api` app deployed to production before access takes effect. Request authorization again when switching to a new hotkey.
+
+Authenticated validator requests use Epistula signatures. The current-kings endpoint used for discriminator weight setting also requires the hotkey to be whitelisted. Other endpoints may enforce additional stake or recent gasstation activity requirements; whitelist membership does not bypass those checks.
+
+If requests return `401 Unauthorized validator`, `Not eligible for current kings`, or `Not eligible for escrow addresses`, confirm that the configured hotkey's public address is in the deployed production whitelist. Hugging Face `gasstation` organization access is separate from GAS API authorization.
+
 ---
 
 ## Quick start: PM2


### PR DESCRIPTION
Document GAS API hotkey authorization as a validator onboarding requirement before the PM2 and Docker quick starts. Explain which public address to provide, the bmcore whitelist PR and production deployment requirement, hotkey changes, and authorization errors.

Clarify that subnet registration and Hugging Face organization access do not grant GAS API authorization, and that other endpoint eligibility checks still apply.

Validation: checked the instructions against bmcore's validator authentication and current-kings/escrow handlers; `git diff --check` passes.
